### PR TITLE
Fixed issue of finish button with sync single step wizard

### DIFF
--- a/src/layout/vertical-nav/VerticalNav.tsx
+++ b/src/layout/vertical-nav/VerticalNav.tsx
@@ -99,7 +99,6 @@ export class VerticalNav extends React.PureComponent<VerticalNavProps, VerticalN
                     });
                 }
             }
-            console.log(child);
             return child;
         });
     }

--- a/src/wizards/CustomStepComponent.tsx
+++ b/src/wizards/CustomStepComponent.tsx
@@ -10,12 +10,18 @@
 
 import * as React from "react";
 import {Input} from "../forms/input/Input";
+import {Button} from "../forms/button";
 
 type CustomStepComponentState = {
     value: string;
 };
 
-export class CustomStepComponent extends React.PureComponent<any, CustomStepComponentState> {
+type CustomStepComponentProps = {
+    wizardRef: any;
+    stepId: number;
+};
+
+export class CustomStepComponent extends React.PureComponent<CustomStepComponentProps, CustomStepComponentState> {
     state: CustomStepComponentState = {
         value: " ",
     };
@@ -31,9 +37,20 @@ export class CustomStepComponent extends React.PureComponent<any, CustomStepComp
 
     render() {
         const {value} = this.state;
+        const {wizardRef, stepId} = this.props;
         return (
             <div style={{width: "166px"}}>
+                {"Enter something"} :
                 <Input name="somevalue" value={value} onChange={this.handleChange} />
+                <br />
+                <Button
+                    onClick={() => {
+                        wizardRef.current!.checkStepValidity(stepId);
+                    }}
+                >
+                    {" "}
+                    Finish Step{" "}
+                </Button>
             </div>
         );
     }

--- a/src/wizards/Wizard.stories.tsx
+++ b/src/wizards/Wizard.stories.tsx
@@ -17,12 +17,15 @@ import {Badge, BadgeStatus, BadgeColor} from "../emphasis/badges";
 import {CustomStepComponent} from "./CustomStepComponent";
 
 const CustomStepComponentRef = React.createRef<CustomStepComponent>();
+// Refrence to call step validation methods of wizard
+const wizardSingleRefSync = React.createRef<Wizard>();
 const SingleStep = [
     {
         stepName: "page 1",
         stepId: 0,
-        stepComponent: <CustomStepComponent ref={CustomStepComponentRef} />,
+        stepComponent: <CustomStepComponent ref={CustomStepComponentRef} wizardRef={wizardSingleRefSync} stepId={0} />,
         onStepSubmit: () => CustomStepComponentRef.current!.resetComponent(),
+        isStepValid: () => true,
     },
 ];
 
@@ -194,9 +197,11 @@ storiesOf("Wizard", module)
                 <Button onClick={() => storeSingleStep.set({show: true})}> Single Step </Button>
                 <State store={storeSingleStep}>
                     <Wizard
+                        ref={wizardSingleRefSync}
                         size={WizardSize.MEDIUM}
                         title="Wizard with Single Step"
                         steps={SingleStep}
+                        validationType={WizardValidationType.SYNC}
                         onClose={() => storeSingleStep.set({show: false})}
                     />
                 </State>

--- a/src/wizards/Wizard.tsx
+++ b/src/wizards/Wizard.tsx
@@ -143,6 +143,13 @@ export class Wizard extends React.PureComponent<WizardProps> {
         const {validationType, steps} = this.props;
         // For 1st step disable Next button for synchronous validation
         const disableNext = validationType === WizardValidationType.SYNC ? true : false;
+        let disableFinish = this.state.disableFinishButton;
+
+        // In case of single step wizard we need to disable Finish button for synchronous validation
+        if (steps.length === 1) {
+            disableFinish = disableNext;
+        }
+
         steps.map((step, key) => {
             // Enable Nav for first step in case of Synchronous validation
             const disableNav =
@@ -153,6 +160,7 @@ export class Wizard extends React.PureComponent<WizardProps> {
 
             this.setState({
                 disableNextButton: this.state.disableNextButton !== disableNext ? disableNext : undefined,
+                disableFinishButton: this.state.disableFinishButton !== disableFinish ? disableFinish : undefined,
                 allSteps: [
                     ...this.state.allSteps,
                     ((this.state.allSteps[step.stepId].stepCompleted = false),


### PR DESCRIPTION
- Issue -  finish button was not getting disabled in case of Wizard with single step and validation type is sychronous validation.
- Modified story for same
- Remvoe console.log from VerticalNav.tsx

![image](https://user-images.githubusercontent.com/51195071/66291254-fcac5380-e8fe-11e9-8d2d-621e81b43d6a.png)
