### PR TITLE
Made totalItems parameter of updateRows() optional  for pagination

### DIFF
--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -246,7 +246,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     componentDidUpdate(prevProps: DataGridProps) {
         const {rows, columns} = this.props;
         if (rows && rows !== prevProps.rows) {
-            this.updateRows(rows, rows.length);
+            this.updateRows(rows);
         }
 
         if (columns !== prevProps.columns) {
@@ -267,12 +267,12 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     };
 
     // Function to update datagrid rows
-    updateRows = (rows: DataGridRow[], totalItems: number) => {
+    updateRows = (rows: DataGridRow[], totalItems?: number) => {
         const updatedRows = this.updateRowIDs(rows);
         let {pagination} = this.state;
 
         // update pagination footer
-        if (pagination) {
+        if (pagination && totalItems) {
             const {pageSize, currentPage} = pagination;
             const firstItem = this.getFirstItemIndex(currentPage, pageSize);
             const lastItem = this.getLastItemIndex(pageSize, totalItems, firstItem);
@@ -286,7 +286,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
         this.setState({
             allRows: [...updatedRows],
-            selectAll: totalItems == 0 ? false : allTrueOnKey(updatedRows, "isSelected"),
+            selectAll: rows.length == 0 ? false : allTrueOnKey(updatedRows, "isSelected"),
             pagination: pagination ? pagination : undefined,
         });
     };

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -272,7 +272,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         let {pagination} = this.state;
 
         // update pagination footer
-        if (pagination && totalItems) {
+        if (pagination && totalItems !== undefined) {
             const {pageSize, currentPage} = pagination;
             const firstItem = this.getFirstItemIndex(currentPage, pageSize);
             const lastItem = this.getLastItemIndex(pageSize, totalItems, firstItem);
@@ -918,7 +918,12 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private buildDataGridPagination(): React.ReactElement {
         const {className, style} = this.props.pagination!;
         const {itemText} = this.state;
-        const {totalItems, firstItem, lastItem, pageSize, pageSizes} = this.state.pagination!;
+        let {totalItems, firstItem, lastItem, pageSize, pageSizes} = this.state.pagination!;
+        if (totalItems === 0) {
+            firstItem = lastItem = 0;
+        }
+        const paginationLabel = firstItem + "-" + lastItem + " of " + totalItems + " " + itemText;
+
         return (
             <div
                 _ngcontent-clarity-c8=""
@@ -927,9 +932,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             >
                 {pageSizes && totalItems >= pageSize && this.buildPageSizesSelect()}
 
-                <div className={classNames([ClassNames.PAGINATION_DESC])}>
-                    {`${firstItem} - ${lastItem} ${" of "} ${totalItems} ${itemText}`}{" "}
-                </div>
+                <div className={classNames([ClassNames.PAGINATION_DESC])}>{paginationLabel}</div>
 
                 {totalItems >= pageSize && this.buildPageButtons()}
             </div>


### PR DESCRIPTION
For pagination the totalItems are total items present in back-end and not just length of data-gird rows.
So changed logic in updateRows() accordingly.