### PR TITLE
Fixed issue of firstitem in pagination label is incorrect

### DIFF
--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -273,14 +273,15 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
         // update pagination footer
         if (pagination && totalItems !== undefined) {
-            const {pageSize, currentPage} = pagination;
+            const {pageSize} = pagination;
+            const currentPage = 1;
             const firstItem = this.getFirstItemIndex(currentPage, pageSize);
             const lastItem = this.getLastItemIndex(pageSize, totalItems, firstItem);
 
             pagination.totalPages = this.getTotalPages(totalItems, pageSize);
             pagination.firstItem = firstItem;
             pagination.lastItem = lastItem;
-            pagination.currentPage = 1;
+            pagination.currentPage = currentPage;
             pagination.totalItems = totalItems;
         }
 


### PR DESCRIPTION
**Description:**
  when we use filtering along with pagination and if user is on page other than first page then first item index in footer label is incorrect.

**Before Fix:**

![image](https://user-images.githubusercontent.com/51195071/68458715-78b0f880-0229-11ea-909c-0848b93f2429.png)


**After Fix:**

![image](https://user-images.githubusercontent.com/51195071/68458677-65059200-0229-11ea-9790-02d0b172ecba.png)
