### PR TITLE
Fix for multiple wizard and datagrid issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@clr/icons": "2.0.0-beta.1",
-        "@clr/ui": "2.2.0",
+        "@clr/icons": "2.3.6",
+        "@clr/ui": "2.3.6",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/jest": "^24.0.11",
         "@types/node": "^11.9.5",

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -278,11 +278,14 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         // update pagination footer
         if (pagination && totalItems !== undefined) {
             const {pageSize} = pagination;
-            const currentPage = 1;
+
+            pagination.totalPages = this.getTotalPages(totalItems, pageSize);
+
+            // Set current page to 1 if it is greater than total pages
+            const currentPage = pagination.currentPage > pagination.totalPages ? 1 : pagination.currentPage;
             const firstItem = this.getFirstItemIndex(currentPage, pageSize);
             const lastItem = this.getLastItemIndex(pageSize, totalItems, firstItem);
 
-            pagination.totalPages = this.getTotalPages(totalItems, pageSize);
             pagination.firstItem = firstItem;
             pagination.lastItem = lastItem;
             pagination.currentPage = currentPage;

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -131,7 +131,7 @@ export type DataGridFooter = {
  */
 export type DataGridSort = {
     defaultSortOrder: SortOrder;
-    isCurrentlySorted?: boolean;
+    isSorted?: boolean;
     sortFunction: (rows: DataGridRow[], order: SortOrder, columnName: string) => Promise<DataGridRow[]>;
 };
 
@@ -511,7 +511,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             // Set currentlySorted flag for all columns as false
             allColumns.forEach(col => {
                 if (col.sort) {
-                    col.sort.isCurrentlySorted = false;
+                    col.sort.isSorted = false;
                 }
             });
 
@@ -525,7 +525,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
                 // update sort order
                 allColumns[columnID].sort!.defaultSortOrder = nextSortOrder;
-                allColumns[columnID].sort!.isCurrentlySorted = true;
+                allColumns[columnID].sort!.isSorted = true;
 
                 this.setState({
                     allRows: [...rows],
@@ -749,7 +749,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                             }
                         >
                             {columnName}
-                            {sort.isCurrentlySorted && sort.defaultSortOrder !== SortOrder.NONE && (
+                            {sort.isSorted && sort.defaultSortOrder !== SortOrder.NONE && (
                                 <Icon
                                     shape={sort.defaultSortOrder == SortOrder.DESC ? "arrow down" : "arrow up"}
                                     className={classNames([

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -67,18 +67,17 @@ export enum FilterType {
 /**
  * State for DataGridFilter:
  * @param {isOpen} check if filter box is open
- * @param {filterValue} filter string
  * @param {transformVal} value for transform css attribute
  */
 type DataGridFilterState = {
     isOpen: boolean;
-    filterValue: any;
     transformVal: string;
 };
 
 export class DataGridFilter extends React.PureComponent<DataGridFilterProps, DataGridFilterState> {
     private refParent = React.createRef<HTMLDivElement>();
     private refChild = React.createRef<HTMLDivElement>();
+    private filterValue: any;
 
     static defaultProps = {
         filterType: FilterType.STR,
@@ -90,9 +89,13 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     // Initial state for filter
     state: DataGridFilterState = {
         isOpen: false,
-        filterValue: undefined,
         transformVal: "translateX(0px) translateY(0px)",
     };
+
+    constructor(props: DataGridFilterProps) {
+        super(props);
+        this.filterValue = undefined;
+    }
 
     componentWillMount() {
         window.addEventListener("resize", this.resize as any, true);
@@ -118,7 +121,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     }
 
     getFilterValue = () => {
-        return this.state.filterValue;
+        return this.filterValue;
     };
 
     updateFilter = (value: any) => {
@@ -128,13 +131,13 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
         const rows = datagridRef.current!.getAllRows();
 
         if (onFilter && datagridRef) {
-            this.setState({filterValue: value}, () =>
-                onFilter(rows, value, columnName).then(data => {
-                    // Update datagrid rows
-                    const {rows, totalItems} = data;
-                    datagridRef.current!.updateRows(rows, totalItems);
-                }),
-            );
+            this.filterValue = value;
+
+            onFilter(rows, value, columnName).then(data => {
+                // Update datagrid rows
+                const {rows, totalItems} = data;
+                datagridRef.current!.updateRows(rows, totalItems);
+            });
         }
     };
 
@@ -178,7 +181,8 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
 
     // Function to render filter box
     private openFilter(): React.ReactElement {
-        const {filterValue, transformVal} = this.state;
+        const {filterValue} = this;
+        const {transformVal} = this.state;
         const {style, className, filterType, customFilter} = this.props;
 
         return (
@@ -230,7 +234,8 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     }
 
     render() {
-        const {isOpen, filterValue} = this.state;
+        const {isOpen} = this.state;
+        const {filterValue} = this;
         const FilterBtnClasses = classNames([
             ClassNames.DATAGRID_FILTER_BUTTON,
             filterValue && ClassNames.DATAGRID_FILTERED,

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -212,7 +212,11 @@ export const sortColumns = [
     },
     {columnName: "Name", style: {width: "96px"}, sort: {defaultSortOrder: SortOrder.NONE, sortFunction: sortFunction}},
     {columnName: "Creation Date", style: {width: "96px"}},
-    {columnName: "Favorite color", style: {width: "96px"}},
+    {
+        columnName: "Favorite color",
+        style: {width: "96px"},
+        sort: {defaultSortOrder: SortOrder.ASC, sortFunction: sortFunction, isCurrentlySorted: true},
+    },
 ];
 
 /**

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -215,7 +215,7 @@ export const sortColumns = [
     {
         columnName: "Favorite color",
         style: {width: "96px"},
-        sort: {defaultSortOrder: SortOrder.ASC, sortFunction: sortFunction, isCurrentlySorted: true},
+        sort: {defaultSortOrder: SortOrder.ASC, sortFunction: sortFunction, isSorted: true},
     },
 ];
 

--- a/src/wizards/Wizard.stories.tsx
+++ b/src/wizards/Wizard.stories.tsx
@@ -52,7 +52,7 @@ const stepsLarge = [
 ];
 
 const stepsXLarge = [
-    {stepName: "page 1", stepId: 0, stepComponent: <p> Page 1</p>},
+    {stepName: "page 1", stepId: 0, stepComponent: <p> Page 1</p>, showStepTitle: false},
     {stepName: "page 2", stepId: 1, stepComponent: <p> Page 2</p>},
     {stepName: "page 3", stepId: 2, stepComponent: <p> Page 3</p>},
 ];

--- a/src/wizards/Wizard.tsx
+++ b/src/wizards/Wizard.tsx
@@ -24,10 +24,24 @@ import {VerticalNav} from "../layout/vertical-nav";
  * the steps are marked with a green bar to the left.
  */
 
+/**
+ * Step details for wizard
+ * @param {stepName} Name or title for step this name will be used in
+ * left side Navigation as well.
+ * @param {stepComponent} React component for step
+ * @param {stepId} unique ID to identfy the steo should start from 0
+ * @param {showStepTitle} if false do not show step title
+ * @param {stepCompleted} flag to check if step is valid and complete
+ * @param {customStepNav} custom navigation details for step
+ * @param {disableNav} if true then navigation for step is disabled
+ * @param {isStepValid} function to check validity of step
+ * @param {onStepSubmit} function to perform on step submission
+ */
 type WizardStep = {
     stepName: string;
     stepComponent: React.ReactNode;
     stepId: number;
+    showStepTitle?: boolean;
     stepCompleted?: boolean;
     customStepNav?: WizardStepNavDetails;
     disableNav?: boolean;
@@ -625,7 +639,8 @@ export class Wizard extends React.PureComponent<WizardProps> {
                                             <div className={ClassNames.MODAL_TITLE_WRAPPER}>
                                                 <h3 className={ClassNames.MODAL_TITLE} style={Styles.MODAL_TITELE}>
                                                     <span className={ClassNames.MODAL_TITLE_TEXT}>
-                                                        {steps[this.state.currentStepId].stepName}
+                                                        {steps[this.state.currentStepId].showStepTitle !== false &&
+                                                            steps[this.state.currentStepId].stepName}
                                                     </span>
                                                 </h3>
                                             </div>


### PR DESCRIPTION
**Description:**
This PR has fixed following bugs:
- FLEX-2260 :  Common Component -> Data Grid -> Footer bar does not update even if the Data Grid is updated (https://asdjira.isus.emc.com:8443/browse/FLEX-2260)
- FLEX-2190 : Object Store/Common Components - Events - Sorting ICONS not working as expected (https://asdjira.isus.emc.com:8443/browse/FLEX-2190)
-  FLEX-2188 Object Store - Buckets - Showing worng number in footer (https://asdjira.isus.emc.com:8443/browse/FLEX-2188)
- FLEX-2040 : Do not show multiple sorting arrows at a time in datagrid (https://asdjira.isus.emc.com:8443/browse/FLEX-2040)
- Removed multiple setState() from DataGridFilter component
- Added prop to hide/show step title in wizard

**Datagrid:**
- With filter box and only one sorting arrow
![image](https://user-images.githubusercontent.com/51195071/73863785-990f4400-4866-11ea-9f22-0e99fb03b97b.png)

- Updating datagrid footer
  1. Datagrid footer before delete of an objectStore

![image](https://user-images.githubusercontent.com/51195071/73864104-18047c80-4867-11ea-9e43-0a1b59c2499a.png)

 2. Datagrid footer after delete of an objectStore

![image](https://user-images.githubusercontent.com/51195071/73864239-5306b000-4867-11ea-8048-3dd3feffd1d1.png)


**Wizard:**
- Step without title
![image](https://user-images.githubusercontent.com/51195071/73863566-4b92d700-4866-11ea-95f7-84c26a5caee3.png)

 
