### PR TITLE
[FLEX-2214] Bugfix: multiple e bug in number input

### DIFF
--- a/src/forms/input/Input.tsx
+++ b/src/forms/input/Input.tsx
@@ -51,6 +51,14 @@ export class Input extends React.PureComponent<InputProps> {
         if (onChange) onChange(evt);
     };
 
+    //prevents 'e' button click when input type is number
+    private handleKeyDown = (evt: React.KeyboardEvent) => {
+        const {type} = this.props;
+        if (type === "number" && evt.key === "e") {
+            evt.preventDefault();
+        }
+    };
+
     private static renderHelperText(helperText: ReactNode): ReactNode {
         return <span className="clr-subtext">{helperText}</span>;
     }
@@ -94,6 +102,7 @@ export class Input extends React.PureComponent<InputProps> {
                     placeholder={placeholder}
                     data-qa={dataqa}
                     onChange={this.handleChange}
+                    onKeyDown={this.handleKeyDown}
                     onBlur={onBlur}
                     style={style}
                     required={required}


### PR DESCRIPTION
Restrict keydown for 'e' only if input type is number. Other non numeric keys are disabled by default as we set type=="number".  

Note: type="number" feature supported by following browsers
https://www.w3schools.com/tags/att_input_type_number.asp

Tested for chrome and firefox (Both latest versions)
-> for Chrome it worked
-> for Firefox it didn't work.