### PR TITLE
Added promises for wizard callbacks rather than normal function call

### DIFF
--- a/src/wizards/CustomStepComponent.tsx
+++ b/src/wizards/CustomStepComponent.tsx
@@ -27,7 +27,10 @@ export class CustomStepComponent extends React.PureComponent<CustomStepComponent
     };
 
     resetComponent() {
-        this.setState({value: " "});
+        return new Promise((resolve, reject) => {
+            this.setState({value: " "});
+            resolve();
+        });
     }
 
     private handleChange = (evt: React.ChangeEvent<any>) => {

--- a/src/wizards/Wizard.stories.tsx
+++ b/src/wizards/Wizard.stories.tsx
@@ -151,8 +151,11 @@ const stepsAsyncValidation = [
 
 // Function to close and reset wizard
 const closeWizard = () => {
-    wizardRefClose.current!.close();
-    wizardRefClose.current!.resetWizard();
+    return new Promise((resolve, reject) => {
+        wizardRefClose.current!.close();
+        wizardRefClose.current!.resetWizard();
+        resolve();
+    });
 };
 
 const stepclosewizard = [


### PR DESCRIPTION
**Description:**
To fix Flex 2216 and 2218 we need to replace functional call backs to wizard steps with promises so that wizard will wait till completion of onStepSubmit/onNext/onPrevious function before going to next/previous step

**Bugs:**
- https://asdjira.isus.emc.com:8443/browse/FLEX-2218
- https://asdjira.isus.emc.com:8443/browse/FLEX-2216

![image](https://user-images.githubusercontent.com/51195071/74508223-7e069900-4f24-11ea-817e-b0528bd4728c.png)
