### PR TITLE
Replace pagination footer with normal footer if rows are less than page size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.22.5",
+    "version": "0.22.6",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1044,7 +1044,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     <div className={classNames([ClassNames.PAGINATION_DESC])}>{paginationLabel}</div>
                 )}
 
-                {totalItems >= pageSize && compactFooter ? this.buildCompactPageButtons() : this.buildPageButtons()}
+                {compactFooter ? this.buildCompactPageButtons() : this.buildPageButtons()}
             </div>
         );
     }
@@ -1072,6 +1072,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private buildDataGridFooter(): React.ReactElement {
         // Need to take this from state in future
         const {footer, pagination} = this.props;
+        const {pageSize, totalItems} = this.state.pagination!;
         return (
             <div
                 className={`${ClassNames.DATAGRID_FOOTER} ${footer && footer.className && footer.className}`}
@@ -1079,7 +1080,9 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             >
                 {footer && footer.hideShowColBtn && this.buildHideShowColumnsBtn()}
                 <div className={ClassNames.DATAGRID_FOOTER_DESC}>
-                    {pagination !== undefined ? this.buildDataGridPagination() : this.buildFooterContent()}
+                    {pagination !== undefined && totalItems >= pageSize
+                        ? this.buildDataGridPagination()
+                        : this.buildFooterContent()}
                 </div>
             </div>
         );


### PR DESCRIPTION
**Description:**
Fixed issue of pagination footer is not changing to normal footer for rows less than page size.

**Screen shots:**

![image](https://user-images.githubusercontent.com/51195071/79319221-aa8b6100-7f25-11ea-9bac-c583b2dda246.png)
![image](https://user-images.githubusercontent.com/51195071/79319256-b414c900-7f25-11ea-8d71-f9b1cb58c757.png)

