### PR TITLE
Fixed issue of basic footer in datagrid

### DIFF
--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1071,8 +1071,16 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // function to build datagrid footer
     private buildDataGridFooter(): React.ReactElement {
         // Need to take this from state in future
-        const {footer, pagination} = this.props;
-        const {pageSize, totalItems} = this.state.pagination!;
+        const {footer} = this.props;
+        const {pagination} = this.state;
+        let renderPaginationFooter = false;
+        if (pagination) {
+            const {totalItems, pageSize} = pagination;
+            if (totalItems && pageSize && totalItems >= pageSize) {
+                renderPaginationFooter = true;
+            }
+        }
+
         return (
             <div
                 className={`${ClassNames.DATAGRID_FOOTER} ${footer && footer.className && footer.className}`}
@@ -1080,9 +1088,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             >
                 {footer && footer.hideShowColBtn && this.buildHideShowColumnsBtn()}
                 <div className={ClassNames.DATAGRID_FOOTER_DESC}>
-                    {pagination !== undefined && totalItems >= pageSize
-                        ? this.buildDataGridPagination()
-                        : this.buildFooterContent()}
+                    {renderPaginationFooter ? this.buildDataGridPagination() : this.buildFooterContent()}
                 </div>
             </div>
         );


### PR DESCRIPTION
**Description:**
Due to PR https://github.com/EMCECS/clarity-react/pull/102 basic datagrid footer was  not rendering correctly. In this PR I have fixed it.

**Screen-shots:**
Without pagination Footer:
![image](https://user-images.githubusercontent.com/51195071/79351622-85fbad00-7f56-11ea-9f51-56ef44d7c0ac.png)

With pagination Footer:
![image](https://user-images.githubusercontent.com/51195071/79351711-a3307b80-7f56-11ea-921e-c50f2dc7ec40.png)

With pagination Footer and Filtering:
![image](https://user-images.githubusercontent.com/51195071/79351796-bba09600-7f56-11ea-88f1-e1448cee457b.png)


