### PR TITLE
Fixed navigation click not working issue in wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.22.6",
+    "version": "0.22.7",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/wizards/Wizard.tsx
+++ b/src/wizards/Wizard.tsx
@@ -407,13 +407,16 @@ export class Wizard extends React.PureComponent<WizardProps> {
         }
     }
 
-    navigationClick(step: WizardStep) {
+    // Function to call on left side navigation click
+    navigationClick(stepId: number) {
+        const step = this.getStepObj(stepId);
+
         if (step && step.customStepNav && step.customStepNav.onNavClick) {
             step.customStepNav.onNavClick().then(() => {
-                this.modifyButtonStates(step.stepId);
+                this.modifyButtonStates(stepId);
             });
         } else {
-            this.modifyButtonStates(step.stepId);
+            this.modifyButtonStates(stepId);
         }
     }
 
@@ -568,7 +571,7 @@ export class Wizard extends React.PureComponent<WizardProps> {
                                         disabled={this.state.allSteps[step.stepId].disableNav}
                                         link={true}
                                         className="clr-wizard-stepnav-link"
-                                        onClick={this.navigationClick.bind(this, step)}
+                                        onClick={this.navigationClick.bind(this, step.stepId)}
                                         icon={this.buildStepIcon(step)}
                                     >
                                         &nbsp;


### PR DESCRIPTION
**Description:**
We are using **navigationClick()** function in plugin code (https://eos2git.cec.lab.emc.com/ECS/ecs-flex-vsphere-plugin) for  **newObjectStore->Review page -> Edit**. So that on click of 'Edit' user can go back to respective step. There we can not pass whole 'Step' object so reverting back parameter for this function from Step object to stepId.

**Bug**: https://jira.cec.lab.emc.com:8443/browse/OBSDEF-109

**Screen shots:**
Working of Edit on review page of new object store wizard :

![image](https://user-images.githubusercontent.com/51195071/79690112-64603580-8276-11ea-99e6-30911283c137.png)

![image](https://user-images.githubusercontent.com/51195071/79690141-8bb70280-8276-11ea-824d-cb1a40c647bf.png)

![image](https://user-images.githubusercontent.com/51195071/79690150-94a7d400-8276-11ea-8874-3975eff2326f.png)


Working of custom step navigation click :

![image](https://user-images.githubusercontent.com/51195071/79689683-0599bc80-8274-11ea-8ce1-253b47cc328d.png)

