### PR TITLE
fixed issue of datagrid filter keeps generic history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.22.7",
+    "version": "0.22.8",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -185,7 +185,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     private openFilter(): React.ReactElement {
         const {filterValue} = this;
         const {transformVal} = this.state;
-        const {style, className, filterType, customFilter, placeholder} = this.props;
+        const {style, className, filterType, customFilter, placeholder, columnName} = this.props;
 
         return (
             <div>
@@ -219,8 +219,8 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
                     {filterType === FilterType.STR ? (
                         <input
                             className={ClassNames.CLR_INPUT}
-                            name="search"
-                            type="text"
+                            type="search"
+                            name={`name-${columnName}`}
                             placeholder={placeholder}
                             defaultValue={filterValue}
                             onChange={evt => {


### PR DESCRIPTION
**Description:**
Due to same 'name' attribute 'DataGridFilter' was keeping history of all filters.

**Bug:**
- https://jira.cec.lab.emc.com:8443/browse/OBSDEF-6

**Screen Shots:**

Before Fix:

![image](https://user-images.githubusercontent.com/51195071/80077115-afc25e80-856a-11ea-93b6-5743a544199b.png)

After Fix: 
![image](https://user-images.githubusercontent.com/51195071/80077469-2cedd380-856b-11ea-80d2-f5a2db7257c3.png)


![image](https://user-images.githubusercontent.com/51195071/80077199-ca94d300-856a-11ea-92e3-7b53f0ff8cb0.png)
