### PR TITLE
Added loading spinner in datagrid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.22.8",
+    "version": "0.22.9",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/ClassNames.tsx
+++ b/src/datagrid/ClassNames.tsx
@@ -78,6 +78,9 @@ export class ClassNames {
     public static SWITCH_HEADER: string = "switch-header";
     public static CLR_CHECKBOX_WRAPPER: string = "clr-checkbox-wrapper";
     public static SWITCH_CONTENT: string = "switch-content list-unstyled";
+    public static DATAGRID_SPINNER: string = "datagrid-spinner";
+    public static DATAGRID_OUTER_WRAPPER: string = "datagrid-outer-wrapper";
+    public static DATAGRID_INNER_WRAPPER: string = "datagrid-inner-wrapper";
 }
 
 export class Styles {

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -128,6 +128,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
 
     updateFilter = (value: any) => {
         const {columnName, datagridRef, onFilter} = this.props;
+        datagridRef.current!.showLoader();
 
         // get latest data from grid
         const rows = datagridRef.current!.getAllRows();
@@ -139,6 +140,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
                 // Update datagrid rows
                 const {rows, totalItems} = data;
                 datagridRef.current!.updateRows(rows, totalItems);
+                datagridRef.current!.hideLoader();
             });
         }
     };

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -199,7 +199,11 @@ export const sortFunction = (rows: DataGridRow[], sortOrder: SortOrder, columnNa
                 return result;
             },
         );
-        resolve(rows);
+
+        // Purposefully added dealy here to see loading spinner
+        setTimeout(function() {
+            resolve(rows);
+        }, 2000);
     });
 };
 
@@ -369,7 +373,10 @@ export const getPageData = (pageIndex: number, pageSize: number): Promise<DataGr
         } else if (pageSize == 10) {
             rows = paginationRows;
         }
-        resolve(rows);
+        // Purposefully added dealy here to see loading spinner
+        setTimeout(function() {
+            resolve(rows);
+        }, 2000);
     });
 };
 
@@ -410,7 +417,11 @@ export const pageFilterFunction = (
                 totalItems: newRows.length,
             };
         }
-        resolve(result);
+
+        // Purposefully added dealy here to see loading spinner
+        setTimeout(function() {
+            resolve(result);
+        }, 2000);
     });
 };
 


### PR DESCRIPTION
**Description :**
This PR has taken care of following things.
-  Added loading spinner in datagrid on pagination, filtering, and sorting
-  Fixed issue of  missing bottom border of last row in datagrid

**Bugs :**
- https://jira.cec.lab.emc.com:8443/browse/OBSDEF-24

**Screen Shots :**

Added border for last row 

![image](https://user-images.githubusercontent.com/51195071/80452581-33ea5c80-8944-11ea-9fbb-3945b1be4fec.png)

Added spinners for pagination , filtering and sorting 

![image](https://user-images.githubusercontent.com/51195071/80452646-52e8ee80-8944-11ea-8aa2-d45ad7106dfb.png)

![image](https://user-images.githubusercontent.com/51195071/80452671-5da38380-8944-11ea-93ad-33777761ce67.png)

![image](https://user-images.githubusercontent.com/51195071/80452705-6ac07280-8944-11ea-8720-6b6a0ac777c3.png)

![image](https://user-images.githubusercontent.com/51195071/80452728-790e8e80-8944-11ea-9a64-e8b0bf9a01d2.png)

