### PR TITLE
Fix issue of button group not getting updated after changes in props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.22.12",
+    "version": "0.22.13",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/forms/button/ButtonGroup.tsx
+++ b/src/forms/button/ButtonGroup.tsx
@@ -16,7 +16,8 @@ import {classNames} from "../../utils";
  * @param {className} css stylke
  * @param {children} childern UI
  * @param {style} css style
- * @param {defaultValue} default value to be passed
+ * @param {defaultValue} default value for button group
+ * @param {selectedValue} selected value for button group
  * @param {label} name for group
  * @param {disabled} enable disable property
  * @param {isRadio} radio group property
@@ -28,6 +29,7 @@ type ButtonGroupProps = {
     children?: React.ReactNode[];
     style?: any;
     defaultValue?: any;
+    selectedValue?: any;
     label?: string;
     disabled?: boolean;
     isRadio?: boolean;
@@ -45,14 +47,14 @@ export class ButtonGroup extends React.PureComponent<ButtonGroupProps> {
 
     constructor(props: ButtonGroupProps) {
         super(props);
-        const {defaultValue} = props;
-        if (defaultValue) this.state = {value: defaultValue};
+        const {defaultValue, selectedValue} = props;
+        this.state = {value: selectedValue ? selectedValue : defaultValue};
     }
 
     componentDidUpdate(prevProps: ButtonGroupProps) {
-        const {defaultValue} = this.props;
-        if (!(defaultValue === prevProps.defaultValue)) {
-            this.setState({value: defaultValue});
+        const {selectedValue, defaultValue} = this.props;
+        if (selectedValue !== prevProps.selectedValue || defaultValue !== prevProps.defaultValue) {
+            this.setState({value: selectedValue ? selectedValue : defaultValue});
         }
     }
 

--- a/src/forms/radio/RadioButtonGroup.tsx
+++ b/src/forms/radio/RadioButtonGroup.tsx
@@ -16,6 +16,7 @@ import {ReactElement, ReactNode} from "react";
 /**
  * RadioButtonGroup Props
  * @param {defaultValue} default value of radio group
+ * @param {selectedValue} selected value for radio group
  * @param {children} nested radio button or group
  * @param {className} css property
  * @param {disabled} property to enable disable radio button group
@@ -28,6 +29,7 @@ import {ReactElement, ReactNode} from "react";
  */
 type RadioButtonGroupProps = {
     defaultValue?: any;
+    selectedValue?: any;
     children?: React.ReactNode[];
     className?: string;
     disabled?: boolean;
@@ -48,8 +50,15 @@ export class RadioButtonGroup extends React.PureComponent<RadioButtonGroupProps>
 
     constructor(props: RadioButtonGroupProps) {
         super(props);
-        const {defaultValue} = props;
-        if (defaultValue) this.state = {value: defaultValue};
+        const {defaultValue, selectedValue} = props;
+        this.state = {value: selectedValue ? selectedValue : defaultValue};
+    }
+
+    componentDidUpdate(prevProps: RadioButtonGroupProps) {
+        const {selectedValue, defaultValue} = this.props;
+        if (selectedValue !== prevProps.selectedValue || defaultValue !== prevProps.defaultValue) {
+            this.setState({value: selectedValue ? selectedValue : defaultValue});
+        }
     }
 
     private handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
**Description:** 
- Fixed issue of ButtonGroup and RadioButtonGroup components not getting updated after changes in props.

**Screen Shots:**
Before Template Selection:
![image](https://user-images.githubusercontent.com/51195071/82822162-f20cf180-9ec2-11ea-901e-f076d998cb85.png)

After Template Selection:
![image](https://user-images.githubusercontent.com/51195071/82822244-149f0a80-9ec3-11ea-9ef6-d2ae5459d029.png)

Normal rendering of button group and radio button group:
![image](https://user-images.githubusercontent.com/51195071/82822311-30a2ac00-9ec3-11ea-97a8-a01f9c3a9a1c.png)

![image](https://user-images.githubusercontent.com/51195071/82822336-3f895e80-9ec3-11ea-80c5-60fc2b74c21f.png)

