### PR TITLE
Added feature in datagrid to show selected row count

### DIFF
--- a/src/datagrid/ClassNames.tsx
+++ b/src/datagrid/ClassNames.tsx
@@ -81,6 +81,10 @@ export class ClassNames {
     public static DATAGRID_SPINNER: string = "datagrid-spinner";
     public static DATAGRID_OUTER_WRAPPER: string = "datagrid-outer-wrapper";
     public static DATAGRID_INNER_WRAPPER: string = "datagrid-inner-wrapper";
+    public static DATAGRID_FOOTER_CHECKBOX: string = "datagrid-footer-select clr-checkbox-wrapper";
+    public static DATAGRID_FORM_CONTROL: string = "clr-form-control-disabled";
+    public static CLR_SELECT: string = "ng-untouched ng-pristine ng-valid";
+    public static CLR_RADIO_WRAPPER: string = "clr-radio-wrapper";
 }
 
 export class Styles {

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -10,6 +10,7 @@
 
 import * as React from "react";
 import {storiesOf} from "@storybook/react";
+import {State, Store} from "@sambego/storybook-state";
 import {DataGrid, GridSelectionType, GridRowType, SortOrder, DataGridFilter, FilterType} from ".";
 import {
     normalColumns,
@@ -29,9 +30,39 @@ import {
     pageFilterFunction,
     hideableColumns,
     hideShowColFooter,
+    selectedRows,
+    getRowData,
 } from "./DataGridValues";
 import {CustomFilter} from "./CustomFilter";
+import {DataGridRow} from "./DataGrid";
 
+const store = new Store({
+    selectedRows: selectedRows,
+    rows: paginationRows.slice(0, 5),
+    selectRowCallback: (row?: DataGridRow) => {
+        const rowID = row && row.rowData[0].cellData;
+        const index = selectedRows.indexOf(rowID);
+        if (row && row.isSelected) {
+            // add element
+            selectedRows.push(rowID);
+        } else {
+            //remove element
+            selectedRows.splice(index, 1);
+        }
+        store.set({
+            selectedRows: selectedRows,
+        });
+    },
+    selectAllCallback: (allSelected?: boolean) => {
+        let selectedRows;
+        if (allSelected) {
+            selectedRows = [41512, 16166, 30574, 2459, 14262];
+        }
+        store.set({
+            selectedRows: allSelected ? selectedRows : [],
+        });
+    },
+});
 // Refrence to call dataGrid methods
 const datagridRef = React.createRef<DataGrid>();
 const datagridActionsRef = React.createRef<GridActions>();
@@ -260,6 +291,26 @@ storiesOf("DataGrid", module)
         <div style={{width: "80%", paddingTop: "5%"}}>
             <DataGrid columns={hideableColumns} rows={normalRows} footer={hideShowColFooter} />
         </div>
+    ))
+    .add("Grid show selected row count", () => (
+        <State store={store}>
+            {state => (
+                <div style={{width: "80%", paddingTop: "5%"}}>
+                    <DataGrid
+                        ref={datagridFullDemoRef}
+                        itemText={"Users"}
+                        columns={normalColumns}
+                        rows={paginationRows.slice(0, 5)}
+                        pagination={paginationDetails}
+                        selectionType={GridSelectionType.MULTI}
+                        selectedRowCount={state.selectedRows.length}
+                        onRowSelect={state.selectRowCallback}
+                        onSelectAll={state.selectAllCallback}
+                        footer={{showFooter: true}}
+                    />
+                </div>
+            )}
+        </State>
     ))
     .add("Grid full demo", () => (
         <div style={{width: "80%", paddingTop: "5%"}}>

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -297,7 +297,6 @@ storiesOf("DataGrid", module)
             {state => (
                 <div style={{width: "80%", paddingTop: "5%"}}>
                     <DataGrid
-                        ref={datagridFullDemoRef}
                         itemText={"Users"}
                         columns={normalColumns}
                         rows={paginationRows.slice(0, 5)}

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -706,25 +706,36 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         const {selectionType} = this.props;
         const {selectAll} = this.state;
         return (
-            <div
-                role="columnheader"
-                className={classNames([
-                    ClassNames.DATAGRID_COLUMN, //prettier
-                    ClassNames.DATAGRID_SELECT,
-                    ClassNames.DATAGRID_FIXED_COLUMN,
-                ])}
-            >
-                <span className={ClassNames.DATAGRID_COLUMN_TITLE}>
-                    {selectionType === GridSelectionType.MULTI && (
-                        <CheckBox
-                            id="select_all"
-                            onChange={evt => this.handleSelectAll(evt)}
-                            ariaLabel="Select All"
-                            checked={selectAll !== undefined ? selectAll : undefined}
-                        />
-                    )}
-                </span>
-                <div className={ClassNames.DATAGRID_COLUMN_SEPARATOR} />
+            <div className={ClassNames.DATAGRID_ROW_STICKY}>
+                <div
+                    role="columnheader"
+                    className={classNames([
+                        ClassNames.DATAGRID_COLUMN, //prettier
+                        ClassNames.DATAGRID_SELECT,
+                        ClassNames.DATAGRID_FIXED_COLUMN,
+                        ClassNames.DATAGRID_NG_STAR_INSERTED,
+                    ])}
+                >
+                    <span className={ClassNames.DATAGRID_COLUMN_TITLE}>
+                        {selectionType === GridSelectionType.MULTI && (
+                            <div
+                                className={classNames([
+                                    ClassNames.CLR_CHECKBOX_WRAPPER,
+                                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                                ])}
+                            >
+                                <CheckBox
+                                    id="select_all"
+                                    onChange={evt => this.handleSelectAll(evt)}
+                                    ariaLabel="Select All"
+                                    className={ClassNames.CLR_SELECT}
+                                    checked={selectAll !== undefined ? selectAll : undefined}
+                                />
+                            </div>
+                        )}
+                    </span>
+                    <div className={ClassNames.DATAGRID_COLUMN_SEPARATOR} />
+                </div>
             </div>
         );
     }
@@ -856,9 +867,8 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             <div className={ClassNames.DATAGRID_HEADER} role="rowgroup">
                 <div className={ClassNames.DATAGRID_ROW} role="row">
                     <div className={ClassNames.DATAGRID_ROW_MASTER}>
-                        <div className={ClassNames.DATAGRID_ROW_STICKY} />
+                        {selectionType && this.buildSelectColumn()}
                         <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
-                            {selectionType && this.buildSelectColumn()}
                             {rowType && rowType === GridRowType.EXPANDABLE && this.buildEmptyColumn()}
                             {allColumns &&
                                 allColumns.map((column: DataGridColumn, index: number) => {

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -173,39 +173,37 @@ export const filterFunction = (
 // Custom sorting function for number and string type
 export const sortFunction = (rows: DataGridRow[], sortOrder: SortOrder, columnName: string): Promise<DataGridRow[]> => {
     return new Promise((resolve, reject) => {
-        rows.sort(
-            (first: DataGridRow, second: DataGridRow): number => {
-                let result = 0;
-                let firstRecord = first.rowData.find(function(element: any) {
-                    if (element.columnName === columnName) return element;
-                });
+        rows.sort((first: DataGridRow, second: DataGridRow): number => {
+            let result = 0;
+            let firstRecord = first.rowData.find(function(element: any) {
+                if (element.columnName === columnName) return element;
+            });
 
-                let secondRecord = second.rowData.find(function(element: any) {
-                    if (element.columnName === columnName) return element;
-                });
+            let secondRecord = second.rowData.find(function(element: any) {
+                if (element.columnName === columnName) return element;
+            });
 
-                if (firstRecord && secondRecord) {
-                    const contentType = typeof firstRecord.cellData;
+            if (firstRecord && secondRecord) {
+                const contentType = typeof firstRecord.cellData;
 
-                    if (sortOrder === SortOrder.ASC) {
-                        if (contentType === "number") {
-                            result = firstRecord.cellData - secondRecord.cellData;
-                        } else if (contentType === "string") {
-                            if (firstRecord.cellData > secondRecord.cellData) result = -1;
-                            else if (firstRecord.cellData < secondRecord.cellData) result = 1;
-                        }
-                    } else if (sortOrder == SortOrder.DESC) {
-                        if (contentType === "number") {
-                            result = secondRecord.cellData - firstRecord.cellData;
-                        } else if (contentType === "string") {
-                            if (secondRecord.cellData > firstRecord.cellData) result = -1;
-                            else if (secondRecord.cellData < firstRecord.cellData) result = 1;
-                        }
+                if (sortOrder === SortOrder.ASC) {
+                    if (contentType === "number") {
+                        result = firstRecord.cellData - secondRecord.cellData;
+                    } else if (contentType === "string") {
+                        if (firstRecord.cellData > secondRecord.cellData) result = -1;
+                        else if (firstRecord.cellData < secondRecord.cellData) result = 1;
+                    }
+                } else if (sortOrder == SortOrder.DESC) {
+                    if (contentType === "number") {
+                        result = secondRecord.cellData - firstRecord.cellData;
+                    } else if (contentType === "string") {
+                        if (secondRecord.cellData > firstRecord.cellData) result = -1;
+                        else if (secondRecord.cellData < firstRecord.cellData) result = 1;
                     }
                 }
-                return result;
-            },
-        );
+            }
+            return result;
+        });
 
         // Purposefully added dealy here to see loading spinner
         setTimeout(function() {
@@ -319,6 +317,8 @@ export const expandableRows = [
     },
 ];
 
+export let selectedRows = [41512, 2459, 83942];
+
 /**
  * Data for Pagination
  */
@@ -331,14 +331,15 @@ export function getRowData() {
         [14262, "Johnson", "Jun 23, 2019", "Blue"],
         [59729, "Sibyl", "Feb 27, 2016", "Red"],
         [92422, "Roslyn", "Apr 26, 2016", "Blue"],
-        [83943, "Lottie", "Mar 2, 2019", "Yellow"],
-        [83943, "Lottie", "Mar 2, 2019", "Yellow"],
+        [83941, "Lottie", "Mar 2, 2019", "Yellow"],
+        [83942, "Lottie", "Mar 2, 2019", "Yellow"],
         [83943, "Lottie", "Mar 2, 2019", "Yellow"],
     ];
 
     let rowValues: DataGridRow[] = [];
-    data.forEach(function(element) {
+    data.forEach(function(element: any) {
         const row: DataGridRow = {
+            isSelected: selectedRows.includes(element[0]),
             rowData: [
                 {
                     columnName: "User ID",
@@ -427,6 +428,7 @@ export const pageFilterFunction = (
 
         // Purposefully added dealy here to see loading spinner
         setTimeout(function() {
+            console.log("rows", rows);
             resolve(result);
         }, 2000);
     });


### PR DESCRIPTION
**Description:**
- Added provision in datagrid to show number of selected rows in datagrid footer
- Added story for same in storybook
- Changed CSS for select cells as per vMware clarity version 3

**Screen Shots:**
For 3 selected rows : 

![image](https://user-images.githubusercontent.com/51195071/89902656-5ad35280-dc04-11ea-913c-cfee52a7ed34.png)

![image](https://user-images.githubusercontent.com/51195071/89902857-979f4980-dc04-11ea-9f73-d16100ffa173.png)

Deselect 1 row : 
![image](https://user-images.githubusercontent.com/51195071/89903040-cb7a6f00-dc04-11ea-99cd-1a1b477013eb.png)

