### PR TITLE
[OBSDEF-1308] datagrid column width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/ClassNames.tsx
+++ b/src/datagrid/ClassNames.tsx
@@ -81,6 +81,13 @@ export class ClassNames {
     public static DATAGRID_SPINNER: string = "datagrid-spinner";
     public static DATAGRID_OUTER_WRAPPER: string = "datagrid-outer-wrapper";
     public static DATAGRID_INNER_WRAPPER: string = "datagrid-inner-wrapper";
+    public static DATAGRID_COL_WIDTH_EXCEEDED_MAX: string = "exceeded-max";
+    public static CLR_SR_ONLY: string = "clr-sr-only";
+    public static NG_TNS_C81_13: string = "ng-tns-c81-13";
+    public static DRAGGABLE_GHOST: string = "draggable-ghost";
+    public static NG_TRIGGER: string = "ng-trigger";
+    public static NG_TRIGGER_LEAVE_ANIMATION: string = "ng-trigger-leaveAnimation";
+    public static BEING_DRAGGED: string = "being-dragged";
 }
 
 export class Styles {
@@ -88,5 +95,12 @@ export class Styles {
         textAlign: "left" as "left",
         webkitBoxFlex: 1,
         flex: 1,
+    };
+    public static DRAGGABLE_GHOST = {
+        visibility: "visible" as "visible",
+        width: "13px",
+        height: "40px",
+        top: "458px",
+        left: "270px",
     };
 }

--- a/src/datagrid/ClassNames.tsx
+++ b/src/datagrid/ClassNames.tsx
@@ -92,6 +92,7 @@ export class ClassNames {
     public static DATAGRID_FORM_CONTROL: string = "clr-form-control-disabled";
     public static CLR_SELECT: string = "ng-untouched ng-pristine ng-valid";
     public static CLR_RADIO_WRAPPER: string = "clr-radio-wrapper";
+    public static STRICT_WIDTH_CLASS = "datagrid-fixed-width";
 }
 
 export class Styles {

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -908,7 +908,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         return (
             <div
                 role="columnheader"
-                className={classNames([ClassNames.DATAGRID_COLUMN, className])}
+                className={classNames([ClassNames.DATAGRID_COLUMN, ClassNames.DATAGRID_NG_STAR_INSERTED, className])}
                 aria-sort="none"
                 style={{...style, width: width + "px"}}
                 key={"col-" + index}
@@ -1010,6 +1010,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         className?: string,
         style?: any,
     ): React.ReactElement {
+        const columnObj = this.getColObject(columnName);
         const width = this.getColWidth(columnName);
         const isColVisible = this.isColVisible(columnName);
 
@@ -1021,6 +1022,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     ClassNames.DATAGRID_CELL,
                     ClassNames.DATAGRID_NG_STAR_INSERTED,
                     isColVisible !== undefined && !isColVisible && ClassNames.DATAGRID_HIDDEN_COLUMN,
+                    columnObj && columnObj.className,
                     className,
                 ])}
                 style={{...style, width: width + "px"}}

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -69,7 +69,7 @@ type DataGridProps = {
  * @param {style} CSS style
  * @param {filter} Filter component
  * @param {isVisible} if true column will be visible else hide it
- * @param {width} Width of datagrid column the default width will be 96px
+ * @param {width} Width of datagrid column the default width will be 100px
  */
 export type DataGridColumn = {
     columnName: string;
@@ -234,7 +234,7 @@ type DataGridPaginationState = {
 };
 
 // Default width of datagrid column in px
-export const DEFAULT_COLUMN_WIDTH = 96;
+export const DEFAULT_COLUMN_WIDTH = 100;
 
 /**
  * DataGrid Componnet :
@@ -902,7 +902,6 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // Function to build datagrid colums
     private buildDataGridColumn(column: DataGridColumn, index: number): React.ReactElement {
         const {columnName, columnID, className, style, sort, filter, width} = column;
-        const transformVal = 0;
         const columnHeight =
             this.datagridTableRef && this.datagridTableRef.current && this.datagridTableRef.current.clientHeight;
 
@@ -911,7 +910,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 role="columnheader"
                 className={classNames([ClassNames.DATAGRID_COLUMN, className])}
                 aria-sort="none"
-                style={{...style, width: width + "px", transform: transformVal}}
+                style={{...style, width: width + "px"}}
                 key={"col-" + index}
             >
                 <div className={ClassNames.DATAGRID_COLUMN_FLEX}>

--- a/src/datagrid/DataGridColumnResize.tsx
+++ b/src/datagrid/DataGridColumnResize.tsx
@@ -20,7 +20,7 @@ import {DataGridColumn} from "./DataGrid";
  */
 
 // Min column width in px
-const MIN_COLUMN_WIDTH = 1;
+const MIN_COLUMN_WIDTH = 96;
 
 /**
  * Props for DataGridColumnResize :
@@ -73,7 +73,8 @@ export class DataGridColumnResize extends React.PureComponent<DataGridColumnResi
             if (column && column.width) {
                 const minWidth = column.width - MIN_COLUMN_WIDTH;
                 let newWidth = column.width + resizedBy;
-                if (minWidth !== undefined && newWidth < -minWidth) {
+
+                if (minWidth !== undefined && resizedBy < -minWidth) {
                     resizedBy = -minWidth;
                     isLessThanMinWidth = true;
                 }
@@ -108,6 +109,7 @@ export class DataGridColumnResize extends React.PureComponent<DataGridColumnResi
         if (column) {
             this.calculateResizedBy(event.clientX).then(result => {
                 column.width = Math.abs(result.newWidth);
+                column.className = ClassNames.STRICT_WIDTH_CLASS;
                 this.setState(
                     {
                         showTracker: false,

--- a/src/datagrid/DataGridColumnResize.tsx
+++ b/src/datagrid/DataGridColumnResize.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as React from "react";
+import {classNames} from "../utils";
+import {ClassNames, Styles} from "./ClassNames";
+import {DataGridColumn} from "./DataGrid";
+
+/**
+ * General component description :
+ * DataGridColumnResize :
+ * component to manage dynamic chnages in datagrid width
+ */
+
+// Min column width in px
+const MIN_COLUMN_WIDTH = 1;
+
+/**
+ * Props for DataGridColumnResize :
+ * @param {column} datagrid column
+ * @param {height} datagrid height
+ * @param {updateColumn} callback function to update datagrid column width
+ * @param {className} CSS class names
+ * @param {style} CSS style
+ */
+export type DataGridColumnResizeProps = {
+    column: DataGridColumn;
+    height: number | null;
+    updateColumn?: (column: DataGridColumn) => void;
+    className?: string;
+    style?: any;
+};
+
+/**
+ * State for DataGridColumnResize :
+ * @param {startX} start position for tracker
+ * @param {moveX} moved position for tracker
+ * @param {showTracker} show width tracker if true
+ * @param {isLessThanMinWidth} show width tracker in red if true
+ */
+type DataGridColumnResizeState = {
+    startX: number;
+    moveX: number;
+    showTracker: boolean;
+    isLessThanMinWidth: boolean;
+};
+
+export class DataGridColumnResize extends React.PureComponent<DataGridColumnResizeProps, DataGridColumnResizeState> {
+    // Initial state for DataGridColumnResize
+    state: DataGridColumnResizeState = {
+        startX: 0,
+        moveX: 0,
+        showTracker: false,
+        isLessThanMinWidth: false,
+    };
+
+    // Function to calculate new width for datagrid column
+    calculateResizedBy = (clientX: number): Promise<any> => {
+        return new Promise((resolve, reject) => {
+            const {startX} = this.state;
+            const {column} = this.props;
+            let resizedBy = clientX - startX;
+            let isLessThanMinWidth = false;
+
+            // calculate new width
+            if (column && column.width) {
+                const minWidth = column.width - MIN_COLUMN_WIDTH;
+                let newWidth = column.width + resizedBy;
+                if (minWidth !== undefined && newWidth < -minWidth) {
+                    resizedBy = -minWidth;
+                    isLessThanMinWidth = true;
+                }
+                newWidth = column.width + resizedBy;
+                resolve({resizedBy, isLessThanMinWidth, newWidth});
+            }
+        });
+    };
+
+    // onDrag event handler
+    moveTracker = (event: React.DragEvent) => {
+        this.calculateResizedBy(event.clientX).then(result => {
+            this.setState({
+                moveX: result.resizedBy,
+                isLessThanMinWidth: result.isLessThanMinWidth,
+            });
+        });
+    };
+
+    // Function to show width tracker on drag start
+    showTracker = (event: React.DragEvent) => {
+        this.setState({
+            startX: event.clientX,
+            moveX: 0,
+            showTracker: true,
+        });
+    };
+
+    // Function to hide width tracker on drag end
+    hideTracker = (event: React.DragEvent) => {
+        const {column, updateColumn} = this.props;
+        if (column) {
+            this.calculateResizedBy(event.clientX).then(result => {
+                column.width = Math.abs(result.newWidth);
+                this.setState(
+                    {
+                        showTracker: false,
+                        moveX: 0,
+                        startX: 0,
+                    },
+                    () => updateColumn && updateColumn(column),
+                );
+            });
+        }
+    };
+
+    render() {
+        const {height} = this.props;
+        const {moveX, showTracker, isLessThanMinWidth} = this.state;
+        const transformVal = "translateX(" + moveX + "px)";
+
+        return (
+            <div className={classNames([ClassNames.DATAGRID_COLUMN_SEPARATOR, ClassNames.DATAGRID_NG_STAR_INSERTED])}>
+                <div
+                    aria-hidden="true"
+                    draggable={true}
+                    onDragStart={(evt: React.DragEvent) => this.showTracker(evt)}
+                    onDrag={(evt: React.DragEvent) => this.moveTracker(evt)}
+                    onDragEndCapture={(evt: React.DragEvent) => this.hideTracker(evt)}
+                    className={classNames([ClassNames.DATAGRID_COLUMN_HANDLE, showTracker && ClassNames.BEING_DRAGGED])}
+                />
+                {
+                    <div
+                        className={classNames([
+                            ClassNames.NG_TNS_C81_13,
+                            ClassNames.DRAGGABLE_GHOST,
+                            ClassNames.NG_TRIGGER,
+                            ClassNames.NG_TRIGGER_LEAVE_ANIMATION,
+                            ClassNames.DATAGRID_NG_STAR_INSERTED,
+                        ])}
+                        style={Styles.DRAGGABLE_GHOST}
+                    >
+                        <div
+                            aria-hidden="true"
+                            draggable={true}
+                            className={classNames([ClassNames.DATAGRID_COLUMN_HANDLE, ClassNames.NG_TNS_C81_13])}
+                        />
+                    </div>
+                }
+                <span className={ClassNames.CLR_SR_ONLY}></span>
+                <div
+                    className={classNames([
+                        ClassNames.DATAGRID_COLUMN_RESIZE,
+                        isLessThanMinWidth && ClassNames.DATAGRID_COL_WIDTH_EXCEEDED_MAX,
+                    ])}
+                    style={{
+                        display: showTracker ? "block" : "none",
+                        height: height ? height + "px" : "auto",
+                        transform: transformVal,
+                    }}
+                />
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
**Description:**
- Added feature in datagrid to change width of datagrid column using width dragger

**Bug:**
- https://jira.cec.lab.emc.com/browse/OBSDEF-1308

**Screen Shots:**
Original Grid
![image](https://user-images.githubusercontent.com/51195071/91131283-7b061580-e6ca-11ea-9e56-dd99d91fbc8d.png)

After increasing column width:
![image](https://user-images.githubusercontent.com/51195071/91131464-89543180-e6ca-11ea-94dc-0180b740b059.png)

After decreasing column width:
![image](https://user-images.githubusercontent.com/51195071/91157666-405ca700-e6e3-11ea-9604-6ae3acff0ab5.png)


Min width indicator: 
![image](https://user-images.githubusercontent.com/51195071/91157766-62eec000-e6e3-11ea-9b08-5f411fa5fc6b.png)


