### PR TITLE
Wizard  : Added provision to configure  footer buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.23.3",
+    "version": "0.23.4",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -316,4 +316,52 @@ storiesOf("New Wizard", module)
                 </React.Fragment>
             )}
         </State>
+    ))
+    .add("wizard with single apply button", _props => (
+        <State store={store}>
+            {state => (
+                <React.Fragment>
+                    <Button key={0} primary link onClick={() => state.handleToggleWizard(WizardSize.LARGE)}>
+                        OPEN WIZARD
+                    </Button>
+                    <Wizard
+                        currentStepID={state.currentWizardStepID}
+                        key={1}
+                        size={WizardSize.LARGE}
+                        show={state.open}
+                        showPrevious={false}
+                        showNext={false}
+                        showComplete={true}
+                        showCancel={true}
+                        completeText={"Apply"}
+                        title="Wizard with single apply button"
+                        onClose={() => state.handleClose()}
+                        onComplete={() => state.handleComplete()}
+                        onNavigateTo={state.handleSelectStep}
+                    >
+                        <WizardStep
+                            id={0}
+                            key={0}
+                            name={"Page 1"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                        <WizardStep
+                            id={1}
+                            key={1}
+                            name={"Page 2"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                        <WizardStep
+                            id={2}
+                            key={2}
+                            name={"Page 3"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                    </Wizard>
+                </React.Fragment>
+            )}
+        </State>
     ));

--- a/src/newWizard/Wizard.tsx
+++ b/src/newWizard/Wizard.tsx
@@ -38,13 +38,14 @@ import WizardFooter, {InheritedWizardFooterProps, WizardFooterProps} from "./Wiz
  * @param {closable} if true user can close the wizard
  * @param {onClose} callback function to call on close of wizard
  * @param {previousText} custom text for previous button
- * @param {showPreviousButton} if true show previous button on wizard else hide
+ * @param {showNext} if true show next button on wizard else hide
  * @param {onPrevious} callback function to call on click of previous button
  * @param {previousClassName} external CSS for previous button
  * @param {nextButtonText} custom text for next button
  * @param {onNext} callback function to call on click of next button
  * @param {nextClassName} external CSS for next button
  * @param {completeText} custom text for finish button
+ * @param {showComplete} if true show finish button on wizard else hide
  * @param {onComplete} callback function to call on click of finish button
  * @param {completeClassName} external CSS for finish button
  * @param {cancelText} custom text for cancel button
@@ -96,18 +97,20 @@ export type WizardProps = {
     dataqa?: string;
     showNavigation?: boolean;
     closable?: boolean;
-    completeText?: string;
     isInline?: boolean;
     showPrevious?: boolean;
     previousClassName?: string;
+    previousText?: string;
     nextText?: string;
+    showNext?: boolean;
     nextClassName?: string;
     onClose?: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     onComplete?: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     onNext?: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     onPrevious?: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     onNavigateTo?: (stepID: number, evt: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-    previousText?: string;
+    completeText?: string;
+    showComplete?: boolean;
     completeClassName?: string;
     cancelText?: string;
     showCancel?: boolean;
@@ -177,12 +180,13 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
 
     // and this step's position in the list
     // progressionStatus determines the status of the wizard based on the current step properties
-    private static progressionStatus(currentStepID: number, steps: ReadonlyArray<WizardStep>): ProgressionStatus {
+    private progressionStatus(currentStepID: number, steps: ReadonlyArray<WizardStep>): ProgressionStatus {
+        const {showNext, showPrevious, showStepTitle} = this.props;
         if (steps.length > 0 && steps[currentStepID]) {
             const currentStep = steps[currentStepID];
             return {
-                previousStepExists: currentStepID !== steps[0].props.id,
-                nextStepExists: currentStepID !== steps[steps.length - 1].props.id,
+                previousStepExists: showPrevious !== undefined ? showPrevious : currentStepID !== steps[0].props.id,
+                nextStepExists: showNext !== undefined ? showNext : currentStepID !== steps[steps.length - 1].props.id,
                 currentStepIsCompleteAndValid: (currentStep.props.valid && currentStep.props.complete) || false,
                 currentStepTitle: currentStep.props.name,
             };
@@ -261,7 +265,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             nextStepExists,
             previousStepExists,
             // @ts-ignore // steps is actually of type ReadonlyArray<WizardStep> not ReadonlyArray<ReactElement<WizardStep>>
-        } = Wizard.progressionStatus(currentStepID, steps);
+        } = this.progressionStatus(currentStepID, steps);
 
         const navigationSteps = steps.map((step, index) => (
             // @ts-ignore // since step is of type WizardStep, name and id are ensured on WizardNavigationStep


### PR DESCRIPTION
**Description :**
 - Added code in wizard to configure visibility of wizard footer buttons
 - Added story for same in storybook

**Screen shot:**
wizard with single 'Apply' button and no 'Next' and 'Back' buttons. This wizard will close on Apply and Cancel click

![image](https://user-images.githubusercontent.com/51195071/91556582-94b88e80-e950-11ea-9cad-4df2a5952632.png)

![image](https://user-images.githubusercontent.com/51195071/91556591-9da96000-e950-11ea-8844-fc4bb13accaa.png)
