### PR TITLE
[obsdef-3016] -  Added custom size for modals and added storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.23.6",
+    "version": "0.23.7",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/modals/Modal.stories.tsx
+++ b/src/modals/Modal.stories.tsx
@@ -34,6 +34,11 @@ const storeExtraLarge = new Store({
     closable: true,
 });
 
+const storeCustom = new Store({
+    isOpen: false,
+    closable: true,
+});
+
 storiesOf("Modals", module).add("Modal Sizes", () => (
     <div className="clr-row">
         <div className="clr-col-12">
@@ -96,6 +101,26 @@ storiesOf("Modals", module).add("Modal Sizes", () => (
                     </ModalFooter>
                 </Modal>
                 <Button onClick={() => storeExtraLarge.set({isOpen: !storeExtraLarge.get("isOpen")})}>x-large</Button>
+            </State>
+            <State store={storeCustom}>
+                <Modal
+                    size={ModalSize.CUSTOM}
+                    onClose={() => storeCustom.set({isOpen: false})}
+                    title="Custom modal"
+                    width={500}
+                    height={300}
+                >
+                    <ModalBody>
+                        <p>I'm a Custom sized modal with 500 X 300</p>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button onClick={() => storeCustom.set({isOpen: false})}>cancel</Button>
+                        <Button onClick={() => storeCustom.set({isOpen: false})} primary={true}>
+                            ok
+                        </Button>
+                    </ModalFooter>
+                </Modal>
+                <Button onClick={() => storeCustom.set({isOpen: !storeCustom.get("isOpen")})}>Custom</Button>
             </State>
         </div>
     </div>

--- a/src/modals/Modal.stories.tsx
+++ b/src/modals/Modal.stories.tsx
@@ -109,6 +109,7 @@ storiesOf("Modals", module).add("Modal Sizes", () => (
                     title="Custom modal"
                     width={500}
                     height={300}
+                    className="custom-class"
                 >
                     <ModalBody>
                         <p>I'm a Custom sized modal with 500 X 300</p>

--- a/src/modals/Modal.tsx
+++ b/src/modals/Modal.tsx
@@ -24,6 +24,7 @@ import {ReactNode} from "react";
  * @param {dataqa} Quality Engineering field
  * @param {width} if Size is custom, then width need to be provided in props
  * @param {height} if Size is custom, then height need to be provided in props
+ * @param {className} if className is provided, the add custom class with existing classes
  */
 type ModalProps = {
     isOpen?: boolean;
@@ -34,6 +35,7 @@ type ModalProps = {
     dataqa?: string;
     width?: number;
     height?: number;
+    className?: string;
 };
 
 type ModalState = {
@@ -96,7 +98,7 @@ export class Modal extends React.PureComponent<ModalProps> {
     }
 
     buildModal(): React.ReactElement {
-        const {size, closable, title, children, dataqa, width, height} = this.props;
+        const {size, closable, title, children, dataqa, width, height, className} = this.props;
         return (
             <React.Fragment>
                 <div className={ClassNames.MODAL} data-qa={dataqa}>
@@ -104,6 +106,7 @@ export class Modal extends React.PureComponent<ModalProps> {
                         className={classNames([
                             ClassNames.MODAL_DIALOG, //prettier
                             size && size,
+                            className && className,
                         ])}
                         style={size === ModalSize.CUSTOM ? {width: `${width}px`, height: `${height}px`} : {}}
                         role="dialog"

--- a/src/modals/Modal.tsx
+++ b/src/modals/Modal.tsx
@@ -22,6 +22,8 @@ import {ReactNode} from "react";
  * @param {closable} property stating if modal is closable
  * @param {onClose} function onClose
  * @param {dataqa} Quality Engineering field
+ * @param {width} if Size is custom, then width need to be provided in props
+ * @param {height} if Size is custom, then height need to be provided in props
  */
 type ModalProps = {
     isOpen?: boolean;
@@ -30,6 +32,8 @@ type ModalProps = {
     closable?: boolean;
     onClose?: Function;
     dataqa?: string;
+    width?: number;
+    height?: number;
 };
 
 type ModalState = {
@@ -40,6 +44,7 @@ export enum ModalSize {
     SMALL = "modal-sm",
     LARGE = "modal-lg",
     XLARGE = "modal-xl",
+    CUSTOM = "custom",
 }
 
 export const ModalBody: React.FunctionComponent = ({children}) => {
@@ -91,7 +96,7 @@ export class Modal extends React.PureComponent<ModalProps> {
     }
 
     buildModal(): React.ReactElement {
-        const {size, closable, title, children, dataqa} = this.props;
+        const {size, closable, title, children, dataqa, width, height} = this.props;
         return (
             <React.Fragment>
                 <div className={ClassNames.MODAL} data-qa={dataqa}>
@@ -100,6 +105,7 @@ export class Modal extends React.PureComponent<ModalProps> {
                             ClassNames.MODAL_DIALOG, //prettier
                             size && size,
                         ])}
+                        style={size === ModalSize.CUSTOM ? {width: `${width}px`, height: `${height}px`} : {}}
                         role="dialog"
                         aria-hidden="true"
                     >


### PR DESCRIPTION
JIRA: https://jira.cec.lab.emc.com/browse/OBSDEF-3016

Feature:  Model component was supporting fix sizes for the modal sizing.  Due to this the wrong sizes were getting applied to the Modal Dialogs in case of Standalone application.  So we have added Custom size, where the width and height are directly applied to the Modal. 

**Screenshots:**
with custom style
![image](https://user-images.githubusercontent.com/54625112/94002398-5fedfa80-fd89-11ea-914c-cfc585d17b1d.png)

With Custom Classname
![image](https://user-images.githubusercontent.com/54625112/94011102-62a31c80-fd96-11ea-86b1-a2aa0a77d2a9.png)
