### PR TITLE
[OBDEF-3306] Wizard - add loading spinner on click of Apply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.23.9",
+    "version": "0.24.0",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -41,7 +41,7 @@ import {DataGridRow} from "./DataGrid";
 const store = new Store({
     selectedRows: selectedRows,
     rows: alreadySelectedRows.slice(0, 5),
-    selectRowCallback: (row?: DataGridRow) => {
+    selectRowCallback: (row: DataGridRow) => {
         const rowID = row && row.rowData[0].cellData;
         const index = selectedRows.indexOf(rowID);
         if (row && row.isSelected) {
@@ -55,7 +55,7 @@ const store = new Store({
             selectedRows: selectedRows,
         });
     },
-    selectAllCallback: (allSelected?: boolean, rows?: DataGridRow[]) => {
+    selectAllCallback: (allSelected: boolean, rows: DataGridRow[]) => {
         rows!.forEach(row => {
             const rowID = row.rowData[0].cellData;
             const index = selectedRows.indexOf(rowID);

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -52,8 +52,8 @@ type DataGridProps = {
     columns: DataGridColumn[];
     rows?: DataGridRow[];
     footer?: DataGridFooter;
-    onRowSelect?: (selectedRow?: DataGridRow) => any;
-    onSelectAll?: (areAllSelected?: boolean, selectedRow?: DataGridRow[]) => any;
+    onRowSelect?: (selectedRow: DataGridRow) => void;
+    onSelectAll?: (areAllSelected: boolean, selectedRows: DataGridRow[]) => void;
     keyfield?: string;
     rowType?: GridRowType;
     itemText?: string;

--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -123,7 +123,7 @@ const store = new Store({
             store.set({
                 open: false,
             });
-        }, 7000);
+        }, 5000);
     },
     handleSelectStep: (selectedStepID: number): void => {
         action("selected step ", selectedStepID) &&

--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -64,6 +64,7 @@ function updateSteps(index: number, action: string) {
 
 const store = new Store({
     open: false,
+    isApplying: false,
     activeWizard: "",
     basicInfoValid: true,
     basicInfoComplete: false,
@@ -104,6 +105,26 @@ const store = new Store({
         store.set({
             open: false,
         }),
+    handleSyncComplete: (): void => {
+        action("complete with loading spinner") &&
+            store.set({
+                isApplying: true,
+            });
+
+        // enable wizard navigation and footer after 3 sec
+        setTimeout(function() {
+            store.set({
+                isApplying: false,
+            });
+        }, 3000);
+
+        // Add delay for story only
+        setTimeout(function() {
+            store.set({
+                open: false,
+            });
+        }, 7000);
+    },
     handleSelectStep: (selectedStepID: number): void => {
         action("selected step ", selectedStepID) &&
             store.set({
@@ -358,6 +379,54 @@ storiesOf("New Wizard", module)
                             key={2}
                             name={"Page 3"}
                             navigationTitle={"Click for page 3"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                    </Wizard>
+                </React.Fragment>
+            )}
+        </State>
+    ))
+    .add("wizard with loading spinner", _props => (
+        <State store={store}>
+            {state => (
+                <React.Fragment>
+                    <Button key={0} primary link onClick={() => state.handleToggleWizard(WizardSize.LARGE)}>
+                        OPEN WIZARD
+                    </Button>
+                    <Wizard
+                        currentStepID={state.currentWizardStepID}
+                        key={1}
+                        size={WizardSize.LARGE}
+                        show={state.open}
+                        showCancel={true}
+                        completeText={"Apply"}
+                        title="Wizard with loading spinner on Apply"
+                        onNext={() => state.handleNext()}
+                        onPrevious={() => state.handlePrevious()}
+                        onClose={() => state.handleClose()}
+                        onComplete={() => state.handleSyncComplete()}
+                        onNavigateTo={state.handleSelectStep}
+                        isApplying={state.isApplying}
+                    >
+                        <WizardStep
+                            id={0}
+                            key={0}
+                            name={"Page 1"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                        <WizardStep
+                            id={1}
+                            key={1}
+                            name={"Page 2"}
+                            valid={state.basicInfoValid}
+                            complete={state.basicInfoValid}
+                        />
+                        <WizardStep
+                            id={2}
+                            key={2}
+                            name={"Page 3"}
                             valid={state.basicInfoValid}
                             complete={state.basicInfoValid}
                         />

--- a/src/newWizard/Wizard.tsx
+++ b/src/newWizard/Wizard.tsx
@@ -87,7 +87,7 @@ import WizardFooter, {InheritedWizardFooterProps, WizardFooterProps} from "./Wiz
  * @param {size} indicates the size of the wizard component
  * @param {style} custom inline CSS styles for the wizard component
  * @param {title} title React component to use for the wizard
- *
+ * @param {isApplying} if true then disable navigation and footer and show loading spinner on complete button
  *
  */
 export type WizardProps = {
@@ -123,6 +123,7 @@ export type WizardProps = {
     size: WizardSize;
     style?: Object;
     title?: ReactNode;
+    isApplying?: boolean;
 };
 
 /**
@@ -164,6 +165,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
         showNavigation: true,
         showStepTitle: true,
         showTitle: true,
+        isApplying: false,
         onComplete: () => {
             // by default do nothing in addition the the default handler
         },
@@ -225,6 +227,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             title,
             size,
             style,
+            isApplying,
         } = this.props;
 
         // initialize a bunch of class names
@@ -273,6 +276,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
                 key={step.key || index}
                 currentStepID={currentStepID}
                 onSelectStep={onNavigateTo}
+                isApplying={isApplying}
                 {...step.props}
             />
         ));
@@ -354,6 +358,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             previousText,
             dataqa,
             showCancel,
+            isApplying,
         } = this.props;
         return {
             cancelText,
@@ -367,6 +372,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             previousText,
             dataqa,
             showCancel,
+            isApplying,
         };
     }
 }

--- a/src/newWizard/WizardFooter.tsx
+++ b/src/newWizard/WizardFooter.tsx
@@ -11,6 +11,7 @@
 import React from "react";
 import {ClassNames} from "./ClassNames";
 import {Button, ButtonState} from "../forms/button";
+import {Spinner, SpinnerSize, SpinnerType} from "../spinner/Spinner";
 import {
     dataqa_wizard_btn_cancel,
     dataqa_wizard_btn_finish,
@@ -30,6 +31,7 @@ export type InheritedWizardFooterProps = {
     previousText?: string;
     showCancel?: boolean;
     dataqa?: string;
+    isApplying?: boolean;
 };
 
 export interface WizardFooterProps extends InheritedWizardFooterProps {
@@ -70,7 +72,9 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
             showComplete,
             showNext,
             showPrevious,
+            isApplying,
         } = this.props;
+
         return (
             <div className={ClassNames.WIZARD_FOOTER}>
                 <div className={ClassNames.WIZARD_FOOTER_BUTTON}>
@@ -84,6 +88,7 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
                             className={cancelClassName}
                             dataqa={dataqa + dataqa_wizard_btn_cancel}
                             onClick={onClose}
+                            disabled={isApplying}
                         >
                             {cancelText + " "}
                         </Button>
@@ -94,6 +99,7 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
                             className={previousClassName}
                             dataqa={dataqa + dataqa_wizard_btn_previous}
                             onClick={onPrevious}
+                            disabled={isApplying}
                         >
                             {previousText + " "}
                         </Button>
@@ -115,11 +121,17 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
                             key={completeText}
                             className={completeClassName}
                             state={ButtonState.SUCCESS}
-                            disabled={disableComplete}
+                            disabled={isApplying || disableComplete}
                             dataqa={dataqa + dataqa_wizard_btn_finish}
                             onClick={onComplete}
                         >
-                            {completeText}
+                            {isApplying ? (
+                                <Spinner type={SpinnerType.INLINE} size={SpinnerSize.SMALL}>
+                                    {completeText}
+                                </Spinner>
+                            ) : (
+                                completeText
+                            )}
                         </Button>
                     )}
                 </div>

--- a/src/newWizard/WizardNavigation.tsx
+++ b/src/newWizard/WizardNavigation.tsx
@@ -47,14 +47,15 @@ export class WizardNavigationStep extends React.PureComponent<WizardStepProps> {
     };
 
     render() {
-        const {name, navigationChildren, navigationIcon, navigationTitle, navigable, type} = this.props;
+        const {name, navigationChildren, navigationIcon, navigationTitle, navigable, type, isApplying} = this.props;
+
         return (
             <div
                 className={this.navigationClasses()}
                 style={type && type === WizardStepType.SUB_STEP ? Styles.WIZARD_SUB_STEP_NAV : undefined}
             >
                 <Button
-                    disabled={!navigable}
+                    disabled={isApplying || !navigable}
                     link={true}
                     className="clr-wizard-stepnav-link"
                     onClick={this.handleNavigationClick}

--- a/src/newWizard/WizardStep.tsx
+++ b/src/newWizard/WizardStep.tsx
@@ -31,6 +31,7 @@ export type WizardStepProps = {
     navigationClasses?: ReadonlyArray<string>;
     navigable?: boolean;
     type?: WizardStepType;
+    isApplying?: boolean;
 };
 
 export default class WizardStep extends React.PureComponent<WizardStepProps> {


### PR DESCRIPTION
**Description:**
- Added `isApplying `prop in wizard to show loading spinner on click of Apply
- Added story in storybook for same
- Change signature of select callbacks in datagrid. This change will not harm any existing implementation using datagrid. 

**JIRA:**
- https://jira.cec.lab.emc.com/browse/OBSDEF-3306 


**Testing:**
- Verified working on this changes with vsphere plugin code as well.

![image](https://user-images.githubusercontent.com/51195071/96016820-d9e44180-0e66-11eb-8826-1cd25d3acc70.png)

Storybook:

![image](https://user-images.githubusercontent.com/51195071/96016903-ef596b80-0e66-11eb-8c29-7dc92336d7fa.png)

![image](https://user-images.githubusercontent.com/51195071/96016931-fa140080-0e66-11eb-9810-425b21d48b16.png)

