### PR TITLE
[OBSDEF-3306] [OBSDEF-3410] Added loading spinner in wizard step and fix console errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -293,12 +293,12 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         }
     }
 
-    // funtion to initialize datagrid state
+    // Function to initialize datagrid state
     initializeDataGridState = (): DataGridState => {
         const {isLoading, itemText} = this.props;
         const rows = this.initializeRowData();
         const columns = this.initializeColumnData();
-        const state: DataGridState = {
+        const dataGridState: DataGridState = {
             isLoading: isLoading || false,
             selectAll: this.isAllRowsSelected(rows),
             allColumns: [...columns],
@@ -306,7 +306,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             itemText: itemText || DEFAULT_ITEM_TEXT,
             pagination: this.initializePaginationData(),
         };
-        return state;
+        return dataGridState;
     };
 
     // Function to initialize rows data in state

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -228,6 +228,18 @@ export enum GridRowType {
 }
 
 const isSelectedKey = "isSelected";
+
+// Default label for datagrid items
+const DEFAULT_ITEM_TEXT: string = "items";
+
+// Default width of datagrid column in px
+export const DEFAULT_COLUMN_WIDTH: number = 100;
+
+// Default pagination constants
+export const DEFAULT_CURRENT_PAGE_NUMBER: number = 1;
+export const DEFAULT_PAGE_SIZE: number = 10;
+export const DEFAULT_TOTAL_ITEMS: number = 0;
+
 /**
  * State for DataGrid :
  * @param {selectAll} set to true if all rows got selected else false
@@ -257,9 +269,6 @@ type DataGridPaginationState = {
     compactFooter?: boolean;
 };
 
-// Default width of datagrid column in px
-export const DEFAULT_COLUMN_WIDTH = 100;
-
 /**
  * DataGrid Componnet :
  * Displays data in grid format
@@ -268,37 +277,9 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private pageIndexRef = React.createRef<HTMLInputElement>();
     private datagridTableRef = React.createRef<HTMLDivElement>();
 
-    // Initial state of datagrid
-    state: DataGridState = {
-        isLoading: this.props.isLoading || false,
-        selectAll: false,
-        allColumns: this.props.columns,
-        allRows: this.props.rows !== undefined ? this.props.rows : [],
-        itemText: this.props.itemText !== undefined ? this.props.itemText : "items",
-        pagination:
-            this.props.pagination !== undefined
-                ? {
-                      currentPage:
-                          this.props.pagination.currentPage !== undefined ? this.props.pagination.currentPage : 1,
-                      pageSize: this.props.pagination.pageSize !== undefined ? this.props.pagination.pageSize : 10,
-                      totalItems: this.props.pagination.totalItems !== undefined ? this.props.pagination.totalItems : 0,
-                      pageSizes:
-                          this.props.pagination.pageSizes !== undefined ? this.props.pagination.pageSizes : undefined,
-                      firstItem: 0,
-                      lastItem: 0,
-                      totalPages: 1,
-                      compactFooter:
-                          this.props.pagination.compactFooter !== undefined
-                              ? this.props.pagination.compactFooter
-                              : false,
-                  }
-                : undefined,
-    };
-
     constructor(props: DataGridProps) {
         super(props);
-        this.setInitalState();
-        if (this.props.pagination !== undefined) this.setInitalStateForPagination();
+        this.state = this.initializeDataGridState();
     }
 
     componentDidUpdate(prevProps: DataGridProps) {
@@ -309,6 +290,76 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
         if (columns && columns !== prevProps.columns) {
             this.updateColumns(columns);
+        }
+    }
+
+    // funtion to initialize datagrid state
+    initializeDataGridState = (): DataGridState => {
+        const {isLoading, itemText} = this.props;
+        const rows = this.initializeRowData();
+        const columns = this.initializeColumnData();
+        const state: DataGridState = {
+            isLoading: isLoading || false,
+            selectAll: this.isAllRowsSelected(rows),
+            allColumns: [...columns],
+            allRows: [...rows],
+            itemText: itemText || DEFAULT_ITEM_TEXT,
+            pagination: this.initializePaginationData(),
+        };
+        return state;
+    };
+
+    // Function to initialize rows data in state
+    initializeRowData = (): DataGridRow[] => {
+        const {rows} = this.props;
+        let updatedRows: DataGridRow[] = [];
+        if (rows && rows.length) {
+            updatedRows = this.updateRowIDs(rows);
+            updatedRows.forEach(function(row) {
+                const rowSelectionIsDisabled = row.disableRowSelection !== undefined ? row.disableRowSelection : false;
+                row.isSelected = !rowSelectionIsDisabled && row.isSelected !== undefined ? row.isSelected : false;
+            });
+        }
+        return updatedRows;
+    };
+
+    // Function to initialize columns data in state
+    initializeColumnData = (): DataGridColumn[] => {
+        const {columns} = this.props;
+        let updatedColumns: DataGridColumn[] = [];
+        if (columns && columns.length) {
+            updatedColumns = this.updateColumnIDs(this.setColumnVisibility(columns));
+            updatedColumns.forEach(col => {
+                col.width = col.width ? col.width : DEFAULT_COLUMN_WIDTH;
+            });
+        }
+        return updatedColumns;
+    };
+
+    // Initialize state of grid with pagination
+    private initializePaginationData() {
+        const {pagination} = this.props;
+        if (pagination) {
+            const {currentPage, pageSize, totalItems, compactFooter, pageSizes} = pagination;
+            const currentPageNumber: number = currentPage || DEFAULT_CURRENT_PAGE_NUMBER;
+            const datagridPageSize: number = pageSize || DEFAULT_PAGE_SIZE;
+            const totalItemsInDatagrid: number = totalItems || DEFAULT_TOTAL_ITEMS;
+
+            const firstItem: number = this.getFirstItemIndex(currentPageNumber, datagridPageSize);
+            const lastItem: number = this.getLastItemIndex(datagridPageSize, totalItemsInDatagrid, firstItem);
+
+            const paginationState: DataGridPaginationState = {
+                currentPage: currentPageNumber,
+                pageSize: datagridPageSize,
+                totalItems: totalItemsInDatagrid,
+                pageSizes: pageSizes,
+                compactFooter: compactFooter || false,
+                firstItem: firstItem,
+                lastItem: lastItem,
+                totalPages: this.getTotalPages(totalItemsInDatagrid, datagridPageSize),
+            };
+
+            return paginationState;
         }
     }
 
@@ -412,45 +463,6 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // Function to show loading spinner on datagrid
     showLoader() {
         this.setState({isLoading: true});
-    }
-
-    /* ##########  DataGrid private methods start  ############ */
-
-    // Initialize state of grid
-    private setInitalState() {
-        const {allRows, allColumns} = this.state;
-        let rows = this.updateRowIDs(allRows);
-        const columns = this.updateColumnIDs(this.setColumnVisibility(allColumns));
-        columns.forEach(col => {
-            col.width = col.width ? col.width : DEFAULT_COLUMN_WIDTH;
-        });
-
-        rows.forEach(function(row) {
-            const rowSelectionIsDisabled = row.disableRowSelection !== undefined ? row.disableRowSelection : false;
-            row.isSelected = !rowSelectionIsDisabled && row.isSelected !== undefined ? row.isSelected : false;
-        });
-
-        this.setState({
-            allRows: [...rows],
-            allColumns: [...columns],
-            selectAll: this.isAllRowsSelected(rows),
-        });
-    }
-
-    // Initialize state of grid with pagination
-    private setInitalStateForPagination() {
-        let {pagination} = this.state;
-        if (pagination) {
-            const {currentPage, pageSize, totalItems, compactFooter} = pagination;
-            const firstItem = this.getFirstItemIndex(currentPage, pageSize);
-            const lastItem = this.getLastItemIndex(pageSize, totalItems, firstItem);
-
-            pagination.totalPages = this.getTotalPages(totalItems, pageSize);
-            pagination.firstItem = firstItem;
-            pagination.lastItem = lastItem;
-            pagination.compactFooter = compactFooter !== undefined ? compactFooter : false;
-            this.setState({pagination: pagination});
-        }
     }
 
     /* ############################# Pagination methods start ####################################*/
@@ -1127,11 +1139,11 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                         <select
                             className={classNames([ClassNames.CLR_PAGE_SIZE_SELECT])}
                             onChange={evt => this.handleSelectPageSize(evt)}
+                            defaultValue={pageSize}
                         >
                             {pageSizes!.map((size: number, index: number) => {
-                                const selected = size === pageSize ? true : false;
                                 return (
-                                    <option key={index} value={size} selected={selected}>
+                                    <option key={index} value={size}>
                                         {size}
                                     </option>
                                 );

--- a/src/forms/select/Select.stories.tsx
+++ b/src/forms/select/Select.stories.tsx
@@ -23,6 +23,16 @@ storiesOf("Select", module)
             </Select>
         </div>
     ))
+    .add("Basic select with select option", () => (
+        <div>
+            <Select onChange={action("basic change")}>
+                <SelectOption value="select">select</SelectOption>
+                <SelectOption value="1">One</SelectOption>
+                <SelectOption value="2">Two</SelectOption>
+                <SelectOption value="3">Three</SelectOption>
+            </Select>
+        </div>
+    ))
     .add("Select with custom width", () => (
         <div>
             <Select onChange={action("basic change")} width="30%" label="Basic Select">
@@ -55,6 +65,7 @@ storiesOf("Select", module)
                 defaultHelperText="You have these choices"
                 errorHelperText="This field is required!"
                 label="I've got some options"
+                defaultValue={"2"}
             >
                 <SelectOption value="1">One</SelectOption>
                 <SelectOption value="2">Two</SelectOption>

--- a/src/forms/select/Select.tsx
+++ b/src/forms/select/Select.tsx
@@ -14,7 +14,7 @@ import {Icon} from "../../icon";
 import {classNames} from "../../utils";
 
 type SelectOption = {
-    value?: string;
+    value?: any;
     selected?: boolean;
     disabled?: boolean;
     hidden?: boolean;
@@ -32,6 +32,7 @@ type SelectProps = {
     label?: string;
     id?: string;
     value?: any;
+    defaultValue?: any;
     isBoxed?: boolean;
     required?: boolean; // auto-check on blur if there's a value
     error?: boolean; // force error state of component
@@ -42,7 +43,6 @@ type SelectProps = {
     className?: string;
     style?: any;
     width?: string;
-    showDefaultSelect?: boolean;
     name?: string;
     dataqa?: string;
     disabled?: boolean;
@@ -56,10 +56,10 @@ export class Select extends React.PureComponent<SelectProps> {
     private buildSelect(className: any, setId: string) {
         const {
             value, // prettier
+            defaultValue,
             onBlur,
             onChange,
             children,
-            showDefaultSelect,
             name,
             required,
             id,
@@ -69,6 +69,7 @@ export class Select extends React.PureComponent<SelectProps> {
         return (
             <select
                 value={value} // prettier
+                defaultValue={defaultValue}
                 id={setId || id}
                 name={name}
                 required={required}
@@ -78,9 +79,6 @@ export class Select extends React.PureComponent<SelectProps> {
                 style={{width: this.getSelectWidth()}}
                 disabled={disabled}
             >
-                {!showDefaultSelect && (
-                    <option selected disabled hidden className="hideOption" value="" style={{display: "none"}} />
-                )}
                 {children}
             </select>
         );

--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -429,7 +429,9 @@ storiesOf("New Wizard", module)
                             name={"Page 3"}
                             valid={state.basicInfoValid}
                             complete={state.basicInfoValid}
-                        />
+                        >
+                            <Input name="some-input" label="Some Input" onChange={state.handleValidate} />
+                        </WizardStep>
                     </Wizard>
                 </React.Fragment>
             )}

--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -18,6 +18,7 @@ import {Input} from "../forms/input/Input";
 import {Select, SelectOption} from "../forms/select";
 import {WizardFooterProps} from "./WizardFooter";
 import {action} from "@storybook/addon-actions";
+import {SpinnerSize} from "../spinner/Spinner";
 
 let steps: any[] = [];
 
@@ -408,6 +409,7 @@ storiesOf("New Wizard", module)
                         onComplete={() => state.handleSyncComplete()}
                         onNavigateTo={state.handleSelectStep}
                         isLoading={state.isLoading}
+                        loadingSpinnerSize={SpinnerSize.LARGE}
                     >
                         <WizardStep
                             id={0}

--- a/src/newWizard/Wizard.tsx
+++ b/src/newWizard/Wizard.tsx
@@ -252,6 +252,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
                     Object.assign({}, child.props, {
                         currentStepID,
                         navigable,
+                        isLoading,
                     }),
                 );
                 // subsequent iterations are navigable if all previous iterations are valid

--- a/src/newWizard/Wizard.tsx
+++ b/src/newWizard/Wizard.tsx
@@ -16,6 +16,7 @@ import WizardNavigation, {WizardNavigationStep} from "./WizardNavigation";
 import WizardHeader from "./WizardHeader";
 import WizardStep from "./WizardStep";
 import WizardFooter, {InheritedWizardFooterProps, WizardFooterProps} from "./WizardFooter";
+import {SpinnerSize} from "../spinner/Spinner";
 
 /**
  * General component description :
@@ -88,7 +89,7 @@ import WizardFooter, {InheritedWizardFooterProps, WizardFooterProps} from "./Wiz
  * @param {style} custom inline CSS styles for the wizard component
  * @param {title} title React component to use for the wizard
  * @param {isLoading} if true then disable navigation and footer and show loading spinner on complete button
- *
+ * @param {loadingSpinnerSize} size of loading spinner
  */
 export type WizardProps = {
     className?: string;
@@ -124,6 +125,7 @@ export type WizardProps = {
     style?: Object;
     title?: ReactNode;
     isLoading?: boolean;
+    loadingSpinnerSize?: SpinnerSize;
 };
 
 /**
@@ -228,6 +230,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             size,
             style,
             isLoading,
+            loadingSpinnerSize,
         } = this.props;
 
         // initialize a bunch of class names
@@ -253,6 +256,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
                         currentStepID,
                         navigable,
                         isLoading,
+                        loadingSpinnerSize,
                     }),
                 );
                 // subsequent iterations are navigable if all previous iterations are valid

--- a/src/newWizard/WizardFooter.tsx
+++ b/src/newWizard/WizardFooter.tsx
@@ -109,7 +109,7 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
                             key={nextText}
                             className={nextClassName}
                             primary
-                            disabled={disableNext}
+                            disabled={isLoading || disableNext}
                             dataqa={dataqa + dataqa_wizard_btn_next}
                             onClick={onNext}
                         >

--- a/src/newWizard/WizardStep.tsx
+++ b/src/newWizard/WizardStep.tsx
@@ -33,6 +33,7 @@ export type WizardStepProps = {
     navigable?: boolean;
     type?: WizardStepType;
     isLoading?: boolean;
+    loadingSpinnerSize?: SpinnerSize;
 };
 
 export default class WizardStep extends React.PureComponent<WizardStepProps> {
@@ -40,10 +41,11 @@ export default class WizardStep extends React.PureComponent<WizardStepProps> {
         complete: false,
         valid: true,
         navigationClasses: [],
+        loadingSpinnerSize: SpinnerSize.MEDIUM,
     };
 
     render() {
-        const {children, currentStepID, id, isLoading} = this.props;
+        const {children, currentStepID, id, isLoading, loadingSpinnerSize} = this.props;
         const classNameList = classNames([ClassNames.ACTIVE, ClassNames.WIZARD_PAGE]);
         return (
             <div
@@ -53,7 +55,7 @@ export default class WizardStep extends React.PureComponent<WizardStepProps> {
                 aria-hidden={id !== currentStepID}
                 className={classNameList}
             >
-                {isLoading && <Spinner size={SpinnerSize.MEDIUM} />}
+                {isLoading && <Spinner size={loadingSpinnerSize} />}
                 {children}
             </div>
         );

--- a/src/newWizard/WizardStep.tsx
+++ b/src/newWizard/WizardStep.tsx
@@ -11,6 +11,7 @@
 import * as React from "react";
 import {classNames} from "../utils";
 import {ClassNames} from "./ClassNames";
+import {Spinner, SpinnerSize} from "../spinner/Spinner";
 
 // Enum for wizard step type
 export enum WizardStepType {
@@ -42,7 +43,7 @@ export default class WizardStep extends React.PureComponent<WizardStepProps> {
     };
 
     render() {
-        const {children, currentStepID, id} = this.props;
+        const {children, currentStepID, id, isLoading} = this.props;
         const classNameList = classNames([ClassNames.ACTIVE, ClassNames.WIZARD_PAGE]);
         return (
             <div
@@ -52,6 +53,7 @@ export default class WizardStep extends React.PureComponent<WizardStepProps> {
                 aria-hidden={id !== currentStepID}
                 className={classNameList}
             >
+                {isLoading && <Spinner size={SpinnerSize.MEDIUM} />}
                 {children}
             </div>
         );


### PR DESCRIPTION
**Description :** 
 - Added loading spinner in wizard step
- Fixed below console errors on datagrid and select component

console errors: 
`Warning: Can't call setState on a component that is not yet mounted. This is a no-op, but it might indicate a bug in your application. Instead, assign to `this.state` directly or define a `state = {};` class property with the desired state in the DataGrid component.
    in DataGrid (at DataGrid.stories.tsx:88)
    in div (at DataGrid.stories.tsx:87)
    in div (created by Story)`

`react-dom.development.js:88 Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
    in option (at DataGrid.tsx:1147)
    in select (at DataGrid.tsx:1140)`

**JIRA:**
- https://jira.cec.lab.emc.com/browse/OBSDEF-3306
- https://jira.cec.lab.emc.com/browse/OBSDEF-3410

**Testing:** 
![image](https://user-images.githubusercontent.com/51195071/96408462-2c27b880-1201-11eb-982d-7d7f12042d77.png)

![image](https://user-images.githubusercontent.com/51195071/96408436-229e5080-1201-11eb-99fa-9912c7db6fdc.png)


![image](https://user-images.githubusercontent.com/51195071/96408417-19ad7f00-1201-11eb-81b3-64ac117bf6b5.png)

