### PR TITLE
Added onKeyPress in Password for numeric password

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.24.1",
+    "version": "0.24.2",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/forms/input/Input.stories.tsx
+++ b/src/forms/input/Input.stories.tsx
@@ -96,4 +96,7 @@ storiesOf("Input", module)
                 <Icon shape="search" style={{marginLeft: "-20px", width: "16px", height: "16px"}} />
             </Input>
         </div>
+    ))
+    .add("input with title", () => (
+        <Input name="somevalue" onChange={action("changed")} placeholder="input with title" title={"Title for input"} />
     ));

--- a/src/forms/input/Input.tsx
+++ b/src/forms/input/Input.tsx
@@ -27,6 +27,7 @@ type InputProps = {
     onBlur?: (evt: React.FocusEvent<HTMLInputElement>) => void;
     onKeyDown?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
     onKeyPress?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
+    title?: string;
     placeholder?: string;
     name: string;
     id?: string;
@@ -88,6 +89,7 @@ export class Input extends React.PureComponent<InputProps> {
             required,
             onBlur,
             onKeyPress,
+            title,
             dataqa,
             min,
             max,
@@ -114,6 +116,7 @@ export class Input extends React.PureComponent<InputProps> {
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
                     onKeyPress={onKeyPress}
+                    title={title}
                     onBlur={onBlur}
                     style={style}
                     required={required}

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -13,6 +13,17 @@ import {storiesOf} from "@storybook/react";
 import {action} from "@storybook/addon-actions";
 import {Password} from "./Password";
 
+//Constants for ASCII of numbers
+const ASCII_FOR_ZERO = 48;
+const ASCII_FOR_NINE = 57;
+
+// Function to allow only integers [0-9]
+export const allowOnlyIntegers = (evt: any) => {
+    const charCode = evt.which ? evt.which : evt.keyCode;
+
+    if (charCode < ASCII_FOR_ZERO || charCode > ASCII_FOR_NINE) evt.preventDefault();
+};
+
 storiesOf("Password", module)
     .add("a simple password input", () => <Password name="password" onChange={action("changed")} />)
     .add("a simple password box with defaultValue", () => (
@@ -43,4 +54,7 @@ storiesOf("Password", module)
             errorHelperText="This field is reuired"
         />
     ))
-    .add("Password box without show password icon", () => <Password name="Password" unmask={false} />);
+    .add("Password box without show password icon", () => <Password name="Password" unmask={false} />)
+    .add("Password box which accepts only numbers", () => (
+        <Password name="Password" onKeyPress={allowOnlyIntegers} placeholder="Numeric password" />
+    ));

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -56,5 +56,10 @@ storiesOf("Password", module)
     ))
     .add("Password box without show password icon", () => <Password name="Password" unmask={false} />)
     .add("Password box which accepts only numbers", () => (
-        <Password name="Password" onKeyPress={allowOnlyIntegers} placeholder="Numeric password" />
+        <Password
+            name="Password"
+            onKeyPress={allowOnlyIntegers}
+            placeholder="Numeric password"
+            title={"Numeric password"}
+        />
     ));

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -25,6 +25,7 @@ type PasswordProps = {
     label?: string;
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
     onBlur?: (evt: React.FocusEvent<HTMLInputElement>) => void;
+    onKeyPress?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
     name: string;
     id?: string;
     value?: string;
@@ -85,6 +86,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
             label,
             value,
             defaultValue,
+            onKeyPress,
             errorHelperText,
             error,
             style,
@@ -120,6 +122,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     value={value}
                                     placeholder={placeholder}
                                     required={required}
+                                    onKeyPress={onKeyPress}
                                     type={type}
                                     disabled={disabled}
                                     style={{width: "95%"}}

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -26,6 +26,7 @@ type PasswordProps = {
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
     onBlur?: (evt: React.FocusEvent<HTMLInputElement>) => void;
     onKeyPress?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
+    title?: string;
     name: string;
     id?: string;
     value?: string;
@@ -87,6 +88,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
             value,
             defaultValue,
             onKeyPress,
+            title,
             errorHelperText,
             error,
             style,
@@ -123,6 +125,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     placeholder={placeholder}
                                     required={required}
                                     onKeyPress={onKeyPress}
+                                    title={title}
                                     type={type}
                                     disabled={disabled}
                                     style={{width: "95%"}}


### PR DESCRIPTION
Description:
Added onKeyPress in Password to support only numeric values in PIN in SupportAssist.
Added title for Input.
Added story.

Testing:
http://10.249.253.4:6006

Screenshots:
<img width="957" alt="numeric-password" src="https://user-images.githubusercontent.com/10673883/97672074-6de11a80-1aaf-11eb-9017-2e12cca76dd9.png">
<img width="957" alt="input-with-title" src="https://user-images.githubusercontent.com/10673883/97673343-a1bd3f80-1ab1-11eb-9d89-9921a2aad62f.png">

