### PR TITLE
[OBSDEF-4118] Fixed issue of datagrid loading spinner and scrolling of selectAll column header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.24.4",
+    "version": "0.24.5",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -952,9 +952,11 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             <div className={ClassNames.DATAGRID_HEADER} role="rowgroup">
                 <div className={ClassNames.DATAGRID_ROW} role="row">
                     <div className={ClassNames.DATAGRID_ROW_MASTER}>
-                        {selectionType && this.buildSelectColumn()}
-                        <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
+                        <div className={ClassNames.DATAGRID_ROW_STICKY}>
+                            {selectionType && this.buildSelectColumn()}
                             {rowType && rowType === GridRowType.EXPANDABLE && this.buildEmptyColumn()}
+                        </div>
+                        <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
                             {allColumns &&
                                 allColumns.map((column: DataGridColumn, index: number) => {
                                     return column.isVisible ? this.buildDataGridColumn(column, index) : undefined;
@@ -1335,8 +1337,8 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // render datagrid
     render() {
-        const {className, style, rowType, footer, dataqa} = this.props;
-        const isLoading = this.props.isLoading || this.state.isLoading;
+        const {className, style, rowType, footer, dataqa, isLoading} = this.props;
+        const isDataLoading: boolean = isLoading !== undefined ? isLoading : this.state.isLoading;
 
         return (
             <div
@@ -1355,7 +1357,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                         <div className={ClassNames.DATAGRID_CAL_TABLE}>
                             <div className={ClassNames.DATAGRID_CAL_HEADER} />
                         </div>
-                        {isLoading && this.buildDataGridSpinner()}
+                        {isDataLoading && this.buildDataGridSpinner()}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**Description:**
- Fixed issue on datagrid loading spinner when `props.isLoading `is `false
- Fixed CSS issue on scrolling of selectAll and empty datagrid header


**JIRA:** 
- https://jira.cec.lab.emc.com/browse/OBSDEF-4118

**Testing:**
![image](https://user-images.githubusercontent.com/51195071/100214649-23c84900-2f36-11eb-8889-92a166a8a502.png)

![datagridIssue](https://user-images.githubusercontent.com/51195071/100215323-de584b80-2f36-11eb-9f02-92efa02b4db5.gif)
