### PR TITLE
[OBSDEF-4343] IAM UI: Adding password read-only in Datagrid row

### DIFF
--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -378,6 +378,11 @@ storiesOf("DataGrid", module)
             />
         </div>
     ))
+    .add("Grid with read-only password", () => (
+        <div style={{width: "80%"}}>
+            <DataGrid columns={normalColumns} rows={customRowsWithPassword} footer={customFooter} />
+        </div>
+    ))
     .add("Grid full demo", () => (
         <div style={{width: "80%", paddingTop: "5%"}}>
             <DataGrid
@@ -432,10 +437,5 @@ storiesOf("DataGrid", module)
                 selectionType={GridSelectionType.MULTI}
                 footer={hideShowColFooter}
             />
-        </div>
-    ))
-    .add("Grid with read-only password", () => (
-        <div style={{width: "80%"}}>
-            <DataGrid columns={normalColumns} rows={customRowsWithPassword} footer={customFooter} />
         </div>
     ));

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -17,6 +17,7 @@ import {
     normalColumns,
     normalRows,
     customRows,
+    customRowsWithPassword,
     customFooter,
     defaultFooter,
     GridActions,
@@ -391,5 +392,10 @@ storiesOf("DataGrid", module)
                 selectionType={GridSelectionType.MULTI}
                 footer={hideShowColFooter}
             />
+        </div>
+    ))
+    .add("Grid with read-only password", () => (
+        <div style={{width: "80%"}}>
+            <DataGrid columns={normalColumns} rows={customRowsWithPassword} footer={customFooter} />
         </div>
     ));

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -130,7 +130,7 @@ export const customRowsWithPassword = [
             {
                 columnName: "Favorite color",
                 cellData: (
-                    <div>
+                    <div style={{marginTop: "-35px"}}>
                         <Password
                             name="Password"
                             value="Georgia-pass"
@@ -151,10 +151,10 @@ export const customRowsWithPassword = [
             {
                 columnName: "Favorite color",
                 cellData: (
-                    <div>
+                    <div style={{marginTop: "-35px"}}>
                         <Password
                             name="Password"
-                            value="Brynn-abcdefghijklmnopqr"
+                            value="Brynn-pass"
                             minPasswordLength={8}
                             readOnly={true}
                             style={{border: "none"}}

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -137,7 +137,6 @@ export const customRowsWithPassword = [
                             minPasswordLength={8}
                             readOnly={true}
                             style={{border: "none"}}
-                            formStyle={{marginTop: "0rem"}}
                         />
                     </div>
                 ),

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -158,7 +158,6 @@ export const customRowsWithPassword = [
                             minPasswordLength={8}
                             readOnly={true}
                             style={{border: "none"}}
-                            formStyle={{marginTop: "0rem"}}
                         />
                     </div>
                 ),

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -154,7 +154,7 @@ export const customRowsWithPassword = [
                     <div>
                         <Password
                             name="Password"
-                            value="Brynn-pass"
+                            value="Brynn-abcdefghijklmnopqr"
                             minPasswordLength={8}
                             readOnly={true}
                             style={{border: "none"}}

--- a/src/datagrid/DataGridValues.tsx
+++ b/src/datagrid/DataGridValues.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import {Icon} from "../icon";
 import {Button} from "../forms/button";
 import {SortOrder, DataGridRow, DataGridFilterResult, DataGridColumn, DataGridCell} from ".";
+import {Password} from "../forms/password/Password";
 
 /**
  * General file description :
@@ -113,6 +114,53 @@ export const customRows = [
                     <div>
                         <Icon shape="time" />
                         {"Critical"}
+                    </div>
+                ),
+            },
+        ],
+    },
+];
+
+export const customRowsWithPassword = [
+    {
+        rowData: [
+            {columnName: "User ID", cellData: 41512},
+            {columnName: "Name", cellData: "Georgia"},
+            {columnName: "Creation Date", cellData: "Sep 11, 2008"},
+            {
+                columnName: "Favorite color",
+                cellData: (
+                    <div>
+                        <Password
+                            name="Password"
+                            value="Georgia-pass"
+                            minPasswordLength={8}
+                            readOnly={true}
+                            style={{border: "none"}}
+                            formStyle={{marginTop: "0rem"}}
+                        />
+                    </div>
+                ),
+            },
+        ],
+    },
+    {
+        rowData: [
+            {columnName: "User ID", cellData: 16166},
+            {columnName: "Name", cellData: "Brynn"},
+            {columnName: "Creation Date", cellData: "Aug 2, 2014"},
+            {
+                columnName: "Favorite color",
+                cellData: (
+                    <div>
+                        <Password
+                            name="Password"
+                            value="Brynn-pass"
+                            minPasswordLength={8}
+                            readOnly={true}
+                            style={{border: "none"}}
+                            formStyle={{marginTop: "0rem"}}
+                        />
                     </div>
                 ),
             },

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -65,5 +65,5 @@ storiesOf("Password", module)
         />
     ))
     .add("Password box with read-only value", () => (
-        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none", width: "6%"}} />
+        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none"}} />
     ));

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -65,5 +65,5 @@ storiesOf("Password", module)
         />
     ))
     .add("Password box with read-only value", () => (
-        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none"}} />
+        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none", width: "10%"}} />
     ));

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -63,4 +63,7 @@ storiesOf("Password", module)
             placeholder="Numeric password"
             title={"Numeric password"}
         />
+    ))
+    .add("Password box with read-only value", () => (
+        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none", width: "6%"}} />
     ));

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -40,7 +40,6 @@ type PasswordProps = {
     pattern?: string; // specifies a regular expression that element's value is checked against
     dataqa?: string; //quality engineering testing field
     readOnly?: boolean; //specifies if password is readonly
-    formStyle?: any; //styling for form
 };
 
 type PasswordState = {
@@ -106,7 +105,6 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
             pattern,
             dataqa,
             readOnly,
-            formStyle,
         } = this.props;
 
         const {show, type} = this.state;
@@ -117,7 +115,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
 
         return (
             <div className="clr-form clr-form-horizontal ng-pristine ng-valid ng-touched">
-                <div className={utils.classNames(["clr-form-control", label && "clr-row"])} style={formStyle}>
+                <div className={utils.classNames(["clr-form-control", label && "clr-row"])}>
                     {label && Password.renderLabel(label)}
                     <div className={utils.classNames(classNames)} style={{width: "100%"}}>
                         <div className="clr-input-wrapper">

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -132,7 +132,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     title={title}
                                     type={type}
                                     disabled={disabled}
-                                    style={{width: value ? (value.length + 1) * 8 + "px" : "95%"}}
+                                    style={{width: "95%"}}
                                     className="clr-input ng-pristine ng-invalid ng-touched"
                                     id={id}
                                     pattern={pattern}

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -39,6 +39,8 @@ type PasswordProps = {
     unmask?: boolean; // if true renders eye icon to hide/show or mask/unmask password
     pattern?: string; // specifies a regular expression that element's value is checked against
     dataqa?: string; //quality engineering testing field
+    readOnly?: boolean; //specifies if password is readonly
+    formStyle?: any; //styling for form
 };
 
 type PasswordState = {
@@ -103,6 +105,8 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
             unmask,
             pattern,
             dataqa,
+            readOnly,
+            formStyle,
         } = this.props;
 
         const {show, type} = this.state;
@@ -113,7 +117,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
 
         return (
             <div className="clr-form clr-form-horizontal ng-pristine ng-valid ng-touched">
-                <div className={utils.classNames(["clr-form-control", label && "clr-row"])}>
+                <div className={utils.classNames(["clr-form-control", label && "clr-row"])} style={formStyle}>
                     {label && Password.renderLabel(label)}
                     <div className={utils.classNames(classNames)} style={{width: "100%"}}>
                         <div className="clr-input-wrapper">
@@ -136,6 +140,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     pattern={pattern}
                                     data-qa={dataqa}
                                     onChange={this.handleChange}
+                                    readOnly={readOnly}
                                 />
 
                                 {unmask && (

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -132,7 +132,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     title={title}
                                     type={type}
                                     disabled={disabled}
-                                    style={{width: "95%"}}
+                                    style={{width: value ? (value.length + 1) * 8 + "px" : "95%"}}
                                     className="clr-input ng-pristine ng-invalid ng-touched"
                                     id={id}
                                     pattern={pattern}


### PR DESCRIPTION
Refer - https://jira.cec.lab.emc.com/browse/OBSDEF-4343

Adding Read-only password to datagrid row

As per required Acceptance Criteria
1. Password has been aligned in datagrid row.
2. Password is made readonly 

Refer image for - **Read only password in Datagrid**
![image](https://user-images.githubusercontent.com/71622688/101614581-22694700-3a33-11eb-8363-e758e65f43ed.png)

Refer GIF for - **Read-only password**
![OBSDEF - 4343 - Story_for_Read_only_password](https://user-images.githubusercontent.com/71622688/101620852-0a95c100-3a3b-11eb-98d6-f6ec53b23002.gif)
