### PR TITLE
[OBSDEF-4220] Updated versions for clr-icons and clr-ui to 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.24.5",
+    "version": "25.0.0",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,
@@ -8,8 +8,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@clr/icons": "3.0.0",
-        "@clr/ui": "3.0.0",
+        "@clr/icons": "4.0.7",
+        "@clr/ui": "4.0.7",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/jest": "^24.0.11",
         "@types/node": "^11.9.5",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@clr/icons": "4.0.7",
-        "@clr/ui": "4.0.7",
+        "@clr/icons": "4.0.8",
+        "@clr/ui": "4.0.8",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/jest": "^24.0.11",
         "@types/node": "^11.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,15 +1806,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@clr/icons@4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-4.0.7.tgz#03690adb5faf9dfe034b69b126b6d3295e95ef29"
-  integrity sha512-FCrPk3OWSSgCtYcGKpNAlseimr9dZjJzJ9Bq28y/we3G4Tz05ckodBSpLx9OLr8K3veA6hm8pYGljahqqjXd1Q==
+"@clr/icons@4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-4.0.8.tgz#3ca645ff7eaeb25db6f5cd35ccf55f06f92c4c28"
+  integrity sha512-zrr47GgmK+AhM6yHG1GwXn8rsqpdnJVtr6NaJP8CMDfpwq+GvJY0JB8XNPE/d/Ujg8/RQeKwVYzsqmUltBSzoQ==
 
-"@clr/ui@4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-4.0.7.tgz#695002bea47badc949c42f77790f9e323a81ae50"
-  integrity sha512-YbwtuMr//Ep3pqnJAVuVRX7frP8aIVyLXWO+U+plSCCuLcvxwBXeafBG80jkU7+asCjEd3hdvfzJy/TQuLcE8g==
+"@clr/ui@4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-4.0.8.tgz#1d0963090ce3389fda6483f33ec9cf3c68c1506d"
+  integrity sha512-0nAQ+x4ozG7ErW7Oa2OLrS9AkSyc9fZG6PWxpJoyVRTuB38fF3nORWvAeabHq9OLus3VhRO+yzbJCjxIPFHjRg==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,15 +1806,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@clr/icons@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-3.0.0.tgz#d8faa0b9c8d33a48db8db6e422d1e7c1b343d84f"
-  integrity sha512-3gNVHjze/+uGafyLWZ7mEQbkI24VAnOJoUZTn7XMir7FYbuxIutunUYP0XbK3A5j/F/8LtfEc1g6ArVa9is2xA==
+"@clr/icons@4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-4.0.7.tgz#03690adb5faf9dfe034b69b126b6d3295e95ef29"
+  integrity sha512-FCrPk3OWSSgCtYcGKpNAlseimr9dZjJzJ9Bq28y/we3G4Tz05ckodBSpLx9OLr8K3veA6hm8pYGljahqqjXd1Q==
 
-"@clr/ui@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-3.0.0.tgz#8fc5dea32f2077609a9d005632870d9af9d1a10f"
-  integrity sha512-XUHSAoSu1jnlGn2V4cF/fp05TZixfKgV89dqmOYxPNbHbm1u/ozTHmFvd4N7HO8HgBjki+t5YYBz6YGXlq1pRA==
+"@clr/ui@4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-4.0.7.tgz#695002bea47badc949c42f77790f9e323a81ae50"
+  integrity sha512-YbwtuMr//Ep3pqnJAVuVRX7frP8aIVyLXWO+U+plSCCuLcvxwBXeafBG80jkU7+asCjEd3hdvfzJy/TQuLcE8g==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
**Description:**
Updated and tested `clr/ui` and` clr/icons `packages to version 4.0.x

**JIRA:**
- https://jira.cec.lab.emc.com/browse/OBSDEF-4220
