### PR TITLE
obsdef-5639 - Updated modifer for method to allow it triggered from outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 *.log
 *.iml
 dist
+
+# storybook static content
+/storybook-static

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.24.6",
+    "version": "0.25.3",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,
@@ -8,8 +8,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@clr/icons": "3.0.0",
-        "@clr/ui": "3.0.0",
+        "@clr/icons": "4.0.8",
+        "@clr/ui": "4.0.8",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/jest": "^24.0.11",
         "@types/node": "^11.9.5",

--- a/src/datagrid/ClassNames.tsx
+++ b/src/datagrid/ClassNames.tsx
@@ -94,6 +94,19 @@ export class ClassNames {
     public static CLR_SELECT: string = "ng-untouched ng-pristine ng-valid";
     public static CLR_RADIO_WRAPPER: string = "clr-radio-wrapper";
     public static STRICT_WIDTH_CLASS = "datagrid-fixed-width";
+    public static DATAGRID_DETAIL_OPEN = "datagrid-detail-open";
+    public static DATAGRID_DETAIL_PANE = "datagrid-detail-pane";
+    public static DATAGRID_DETAIL_PANE_CONTENT = "datagrid-detail-pane-content";
+    public static DATAGRID_DETAIL_HEADER = "datagrid-detail-header";
+    public static DATAGRID_DETAIL_HEADER_TITLE = "datagrid-detail-header-title";
+    public static DATAGRID_DETAIL_PANE_CLOSE = "datagrid-detail-pane-close";
+    public static DATAGRID_DETAIL_BODY = "datagrid-detail-body";
+    public static CLR_DG_DETAIL_BODY_WRAPPER = "clr-dg-detail-body-wrapper";
+    public static DATAGRID_ROW_DETAIL_OPEN = "datagrid-row-detail-open";
+    public static DATAGRID_DETAIL_CARET = "datagrid-detail-caret";
+    public static DATAGRID_DETAIL_CARET_BUTTON = "datagrid-detail-caret-button";
+    public static DATAGRID_DETAIL_CARET_ICON = "datagrid-detail-caret-icon";
+    public static IS_OPEN = "is-open";
 }
 
 export class Styles {

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -37,7 +37,8 @@ import {
     paginationDetailsForAlreadySelectedRows,
     rowsWithDetailPane,
     paginationDetailsForDetailsPane,
-} from "./DataGridStoriesData";
+    paginationRowsWithLinks,
+} from "./DataGridValues";
 import {CustomFilter} from "./CustomFilter";
 import {CustomFilterMulti} from "./CustomFilterMulti";
 
@@ -84,6 +85,7 @@ const datagridFilterSortRef = React.createRef<DataGrid>();
 const datagridCustomFilterRef = React.createRef<DataGrid>();
 const datagridCustomFilterMultiRef = React.createRef<DataGrid>();
 const datagridFullDemoRef = React.createRef<DataGrid>();
+const datagridDetailsDemoRef = React.createRef<DataGrid>();
 
 storiesOf("DataGrid", module)
     .add("Basic grid", () => (
@@ -438,4 +440,70 @@ storiesOf("DataGrid", module)
                 footer={hideShowColFooter}
             />
         </div>
-    ));
+    ))
+    .add("Grid Demo with support to open/close details pane", () => {
+        // function to handle
+        const handleLinkClick = (rowIndex: number) => {
+            datagridDetailsDemoRef &&
+                datagridDetailsDemoRef.current &&
+                datagridDetailsDemoRef.current.handleDetailPaneToggle(rowIndex);
+        };
+
+        return (
+            <div style={{width: "80%", paddingTop: "5%"}}>
+                <DataGrid
+                    ref={datagridDetailsDemoRef}
+                    itemText={"Users"}
+                    columns={[
+                        {
+                            columnName: "User ID",
+                            displayName: (
+                                <div>
+                                    <Icon shape="user" className="is-solid" /> {"User ID"}
+                                </div>
+                            ),
+                            isVisible: false,
+                            sort: {defaultSortOrder: SortOrder.ASC, sortFunction: sortFunction},
+                            filter: (
+                                <DataGridFilter
+                                    onFilter={pageFilterFunction}
+                                    columnName={"User ID"}
+                                    datagridRef={datagridFullDemoRef}
+                                />
+                            ),
+                        },
+                        {
+                            columnName: "Name",
+                            displayName: (
+                                <div>
+                                    <Icon shape="administrator" className="is-solid" /> {"Name"}
+                                </div>
+                            ),
+                            sort: {defaultSortOrder: SortOrder.NONE, sortFunction: sortFunction},
+                            filter: (
+                                <DataGridFilter
+                                    onFilter={pageFilterFunction}
+                                    columnName={"Name"}
+                                    datagridRef={datagridFullDemoRef}
+                                />
+                            ),
+                        },
+                        {columnName: "Creation Date", style: {width: "20%"}},
+                        {
+                            columnName: "Favorite color",
+                            displayName: (
+                                <div>
+                                    <Icon shape="color-palette" className="is-solid" /> {"Favorite color"}{" "}
+                                </div>
+                            ),
+                        },
+                    ]}
+                    rows={paginationRowsWithLinks(handleLinkClick).slice(0, 5)}
+                    rowType={GridRowType.ROWS_WITH_DETAIL_PANE}
+                    pagination={paginationDetails}
+                    selectionType={GridSelectionType.MULTI}
+                    footer={hideShowColFooter}
+                />
+            </div>
+        );
+    });

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -17,6 +17,7 @@ import {
     normalColumns,
     normalRows,
     customRows,
+    customRowsWithPassword,
     customFooter,
     defaultFooter,
     GridActions,
@@ -34,7 +35,9 @@ import {
     alreadySelectedRows,
     getSelectableRowsData,
     paginationDetailsForAlreadySelectedRows,
-} from "./DataGridValues";
+    rowsWithDetailPane,
+    paginationDetailsForDetailsPane,
+} from "./DataGridStoriesData";
 import {CustomFilter} from "./CustomFilter";
 import {CustomFilterMulti} from "./CustomFilterMulti";
 
@@ -363,6 +366,23 @@ storiesOf("DataGrid", module)
             )}
         </State>
     ))
+    .add("Grid with detail pane", () => (
+        <div style={{width: "80%", paddingTop: "5%"}}>
+            <DataGrid
+                columns={sortColumns}
+                rows={rowsWithDetailPane.slice(0, 5)}
+                footer={hideShowColFooter}
+                pagination={paginationDetailsForDetailsPane}
+                rowType={GridRowType.EXPANDABLE_ROWS_WITH_DETAIL_PANE}
+                selectionType={GridSelectionType.MULTI}
+            />
+        </div>
+    ))
+    .add("Grid with read-only password", () => (
+        <div style={{width: "80%"}}>
+            <DataGrid columns={normalColumns} rows={customRowsWithPassword} footer={customFooter} />
+        </div>
+    ))
     .add("Grid full demo", () => (
         <div style={{width: "80%", paddingTop: "5%"}}>
             <DataGrid
@@ -376,7 +396,6 @@ storiesOf("DataGrid", module)
                                 <Icon shape="user" className="is-solid" /> {"User ID"}
                             </div>
                         ),
-                        isVisible: false,
                         sort: {defaultSortOrder: SortOrder.ASC, sortFunction: sortFunction},
                         filter: (
                             <DataGridFilter
@@ -405,6 +424,7 @@ storiesOf("DataGrid", module)
                     {columnName: "Creation Date", style: {width: "20%"}},
                     {
                         columnName: "Favorite color",
+                        isVisible: false,
                         displayName: (
                             <div>
                                 <Icon shape="color-palette" className="is-solid" /> {"Favorite color"}{" "}

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -38,7 +38,7 @@ import {
     rowsWithDetailPane,
     paginationDetailsForDetailsPane,
     paginationRowsWithLinks,
-} from "./DataGridValues";
+} from "./DataGridStoriesData";
 import {CustomFilter} from "./CustomFilter";
 import {CustomFilterMulti} from "./CustomFilterMulti";
 

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -657,7 +657,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     }
 
     // Handler for detail pane toggle
-    private handleDetailPaneToggle = (rowID: number) => {
+    public handleDetailPaneToggle = (rowID: number) => {
         let {allRows} = this.state;
         let {detailPaneData} = allRows[rowID];
 

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -96,6 +96,7 @@ export type DataGridColumn = {
  * @param {className} CSS class name
  * @param {style} CSS style
  * @param {expandableContent} Expandable data content
+ * @param {detailPaneData} data for row detail panel
  * @param {disableRowSelection} If true then hide checkbox or radio button to select row.
  */
 export type DataGridRow = {
@@ -104,7 +105,8 @@ export type DataGridRow = {
     style?: any;
     rowID?: number; // not to take from user
     isSelected?: boolean;
-    expandableRowData?: expandableRowDetails;
+    expandableRowData?: ExpandableRowDetails;
+    detailPaneData?: DetailPaneData;
     disableRowSelection?: boolean;
 };
 
@@ -116,12 +118,30 @@ export type DataGridRow = {
  * @param {isExpanded} true if row is already expanded
  * @param {hideRowExpandIcon} if true then hide icon for expandable row
  */
-export type expandableRowDetails = {
+export type ExpandableRowDetails = {
     isLoading?: boolean;
     onRowExpand?: (row: DataGridRow) => Promise<any>;
     expandableContent?: any;
     isExpanded?: boolean;
     hideRowExpandIcon?: boolean;
+};
+
+/**
+ * type for datagrid row detail pane data :
+ * @param {title} title for detail pane
+ * @param {hideDetailPane} if false then render UI for detail panel for row
+ * @param {onOpenDetails} callback function to fetch row detail pane contents
+ * @param {onCloseDetails} callback function to call on close of detail pane contents
+ * @param {detailPaneContent} static content to show in detail pane
+ * @param {isOpen} true if detail pane for row is open
+ */
+export type DetailPaneData = {
+    title?: any;
+    hideDetailPane?: boolean;
+    onOpenDetails?: (row: DataGridRow) => Promise<any>;
+    onCloseDetails?: (row: DataGridRow) => void;
+    detailPaneContent: any;
+    isOpen?: boolean;
 };
 
 /**
@@ -221,10 +241,16 @@ export enum SortOrder {
  * Enum for RowTpye :
  * @param {EXPANDABLE} for enabling expandable rows
  * @param {COMPACT} for enabling compact rows
+ * @param {ROWS_WITH_DETAIL_PANE} for enabling detail pane for rows
+ * @param {EXPANDABLE_ROWS_WITH_DETAIL_PANE} for enabling detail pane for expandable rows
+ * @param {COMPACT_ROWS_WITH_DETAIL_PANE} for enabling detail pane for compact rows
  */
 export enum GridRowType {
     EXPANDABLE = "expandable",
     COMPACT = "compact",
+    ROWS_WITH_DETAIL_PANE = "rows_with_detail_pane",
+    EXPANDABLE_ROWS_WITH_DETAIL_PANE = "expandable_rows_with_detail_pane",
+    COMPACT_ROWS_WITH_DETAIL_PANE = "compact_rows_with_detail_panes",
 }
 
 const isSelectedKey = "isSelected";
@@ -465,6 +491,14 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         this.setState({isLoading: true});
     }
 
+    // Function to close any open detail pane
+    closeDetailPane = () => {
+        if (this.isDetailPaneOpen()) {
+            const row = this.getRowDataWithOpenDetailPane();
+            row && row.rowID !== undefined && this.handleDetailPaneToggle(row.rowID);
+        }
+    };
+
     /* ############################# Pagination methods start ####################################*/
     private getTotalPages = (totalItems: number, pageSize: number) => {
         return Math.floor((totalItems + pageSize - 1) / pageSize);
@@ -577,11 +611,14 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
                 getPageData(pageIndex, pageSize).then((data: DataGridRow[]) => {
                     const rows = this.updateRowIDs(data);
-                    this.setState({
-                        allRows: [...rows],
-                        pagination: paginationState,
-                        selectAll: this.isAllRowsSelected(rows),
-                    });
+                    this.setState(
+                        {
+                            allRows: [...rows],
+                            pagination: paginationState,
+                            selectAll: this.isAllRowsSelected(rows),
+                        },
+                        () => this.closeDetailPane(),
+                    );
                     this.hideLoader();
                 });
             }
@@ -618,6 +655,41 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             }
         }
     }
+
+    // Handler for detail pane toggle
+    private handleDetailPaneToggle = (rowID: number) => {
+        let {allRows} = this.state;
+        let {detailPaneData} = allRows[rowID];
+
+        if (detailPaneData) {
+            detailPaneData.isOpen = !detailPaneData.isOpen;
+            const {isOpen, onOpenDetails, onCloseDetails} = detailPaneData;
+
+            const updatedRows: DataGridRow[] = allRows.map((row: DataGridRow) => {
+                if (row.detailPaneData) {
+                    row.detailPaneData.isOpen = false;
+                }
+                return row;
+            });
+
+            if (isOpen) {
+                // For open panel
+                onOpenDetails &&
+                    onOpenDetails(allRows[rowID]).then((content: any) => {
+                        // For dynamic update of detail content
+                        updatedRows[rowID].detailPaneData!.detailPaneContent = content;
+                    });
+                updatedRows[rowID].detailPaneData!.isOpen = isOpen;
+            }
+
+            this.setState(
+                {
+                    allRows: [...updatedRows],
+                },
+                () => !isOpen && onCloseDetails && onCloseDetails(allRows[rowID]),
+            );
+        }
+    };
 
     // Function to handle select/deselect of all rows
     private handleSelectAll = (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -691,10 +763,13 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 allColumns[columnID].sort!.defaultSortOrder = nextSortOrder;
                 allColumns[columnID].sort!.isSorted = true;
 
-                this.setState({
-                    allRows: [...rows],
-                    allColumns: [...allColumns],
-                });
+                this.setState(
+                    {
+                        allRows: [...rows],
+                        allColumns: [...allColumns],
+                    },
+                    () => this.closeDetailPane(),
+                );
                 this.hideLoader();
             });
         }
@@ -744,7 +819,14 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // Check if column is visible
     private isColVisible(columnName: string) {
         const column = this.getColObject(columnName);
-        return column && column.isVisible;
+
+        // Hide all columns except first visible column if detail pane is open
+        const isColumnVisible =
+            this.isDetailPaneOpen() && column && column.columnID !== this.getFirstVisibleColumn()!.columnID
+                ? false
+                : column && column.isVisible;
+
+        return isColumnVisible;
     }
 
     // Update sorting state of columns
@@ -759,9 +841,79 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         return columns;
     }
 
+    // get details of first visible column
+    private getFirstVisibleColumn = () => {
+        const {allColumns} = this.state;
+        return allColumns.find((column: DataGridColumn) => column.isVisible === true);
+    };
+
+    // Check if datagrid need to render detail Pane for rows
+    private isDatagridWithDetailPane = (): boolean => {
+        const {rowType} = this.props;
+
+        return rowType
+            ? rowType === GridRowType.ROWS_WITH_DETAIL_PANE ||
+                  rowType === GridRowType.EXPANDABLE_ROWS_WITH_DETAIL_PANE ||
+                  rowType === GridRowType.COMPACT_ROWS_WITH_DETAIL_PANE
+            : false;
+    };
+
+    // Get details of row whose detail pane is open
+    private getRowDataWithOpenDetailPane = () => {
+        if (this.isDatagridWithDetailPane()) {
+            return this.state.allRows.find(
+                (row: DataGridRow) => row.detailPaneData && row.detailPaneData.isOpen === true,
+            );
+        }
+    };
+
+    // Check if any detail pane is open in datagrid
+    private isDetailPaneOpen = (): boolean => {
+        return this.isDatagridWithDetailPane() && this.getRowDataWithOpenDetailPane() !== undefined;
+    };
+
     /* ##########  DataGrid private methods end  ############ */
 
     /* ##########  DataGrid DOM methods start  ############ */
+
+    //funtion to render detail pane icon cell
+    private buildDetailPaneToggleIcon({rowID, detailPaneData}: DataGridRow): React.ReactElement {
+        const {id} = this.props;
+        const {isOpen, hideDetailPane} = detailPaneData
+            ? detailPaneData
+            : {
+                  isOpen: false,
+                  hideDetailPane: false,
+              };
+        return (
+            <div
+                className={classNames([
+                    ClassNames.DATAGRID_DETAIL_CARET, //prettier
+                    ClassNames.DATAGRID_FIXED_COLUMN,
+                    ClassNames.DATAGRID_CELL,
+                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                ])}
+            >
+                {!hideDetailPane && (
+                    <Button
+                        key={`${id}-${"detail-toggle"}-${rowID}`}
+                        defaultBtn={false}
+                        onClick={() => rowID !== undefined && this.handleDetailPaneToggle(rowID)}
+                        aria-haspopup="dialog"
+                        className={classNames([ClassNames.DATAGRID_DETAIL_CARET_BUTTON, isOpen && ClassNames.IS_OPEN])}
+                        aria-expanded={isOpen}
+                        aria-controls={`clr-id-${rowID}`}
+                        icon={{
+                            shape: "angle-double",
+                            className: ClassNames.DATAGRID_DETAIL_CARET_ICON,
+                            dir: isOpen ? Direction.LEFT : Direction.RIGHT,
+                        }}
+                    />
+                )}
+            </div>
+        );
+    }
+
     //funtion to render expandable icon cell
     private buildExpandableCell({rowID, expandableRowData}: DataGridRow): React.ReactElement {
         const {id} = this.props;
@@ -854,36 +1006,34 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         const wrapperClassName =
             selectionType === GridSelectionType.MULTI ? ClassNames.CLR_CHECKBOX_WRAPPER : ClassNames.CLR_RADIO_WRAPPER;
         return (
-            <div className={ClassNames.DATAGRID_ROW_STICKY}>
-                <div
-                    role="gridcell"
-                    className={classNames([
-                        ClassNames.DATAGRID_SELECT,
-                        ClassNames.DATAGRID_FIXED_COLUMN,
-                        ClassNames.DATAGRID_CELL,
-                        ClassNames.DATAGRID_NG_STAR_INSERTED,
-                    ])}
-                >
-                    <div className={classNames([wrapperClassName, ClassNames.DATAGRID_NG_STAR_INSERTED])}>
-                        {!row.disableRowSelection &&
-                            (selectionType === GridSelectionType.MULTI ? (
-                                <CheckBox
-                                    id={`${id}-${row.rowID}-select-checkbox`}
-                                    ariaLabel="Select"
-                                    className={ClassNames.CLR_SELECT}
-                                    onChange={evt => this.handleSelectSingle(evt, row.rowID)}
-                                    checked={row.isSelected !== undefined ? row.isSelected : undefined}
-                                />
-                            ) : (
-                                <RadioButton
-                                    value={row.rowID}
-                                    id={`${id}-${row.rowID}-select-radio`}
-                                    className={ClassNames.CLR_SELECT}
-                                    onChange={evt => this.handleSelectSingle(evt, row.rowID)}
-                                    checked={row.isSelected !== undefined ? row.isSelected : undefined}
-                                />
-                            ))}
-                    </div>
+            <div
+                role="gridcell"
+                className={classNames([
+                    ClassNames.DATAGRID_SELECT,
+                    ClassNames.DATAGRID_FIXED_COLUMN,
+                    ClassNames.DATAGRID_CELL,
+                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                ])}
+            >
+                <div className={classNames([wrapperClassName, ClassNames.DATAGRID_NG_STAR_INSERTED])}>
+                    {!row.disableRowSelection &&
+                        (selectionType === GridSelectionType.MULTI ? (
+                            <CheckBox
+                                id={`${id}-${row.rowID}-select-checkbox`}
+                                ariaLabel="Select"
+                                className={ClassNames.CLR_SELECT}
+                                onChange={evt => this.handleSelectSingle(evt, row.rowID)}
+                                checked={row.isSelected !== undefined ? row.isSelected : undefined}
+                            />
+                        ) : (
+                            <RadioButton
+                                value={row.rowID}
+                                id={`${id}-${row.rowID}-select-radio`}
+                                className={ClassNames.CLR_SELECT}
+                                onChange={evt => this.handleSelectSingle(evt, row.rowID)}
+                                checked={row.isSelected !== undefined ? row.isSelected : undefined}
+                            />
+                        ))}
                 </div>
             </div>
         );
@@ -948,18 +1098,29 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private buildDataGridHeader(): React.ReactElement {
         const {selectionType, rowType} = this.props;
         const {allColumns} = this.state;
+        const showEmptyHeader: boolean = rowType && rowType !== GridRowType.COMPACT ? true : false;
+
         return (
             <div className={ClassNames.DATAGRID_HEADER} role="rowgroup">
                 <div className={ClassNames.DATAGRID_ROW} role="row">
                     <div className={ClassNames.DATAGRID_ROW_MASTER}>
                         <div className={ClassNames.DATAGRID_ROW_STICKY}>
                             {selectionType && this.buildSelectColumn()}
-                            {rowType && rowType === GridRowType.EXPANDABLE && this.buildEmptyColumn()}
+                            {rowType &&
+                                rowType === GridRowType.EXPANDABLE_ROWS_WITH_DETAIL_PANE &&
+                                this.buildEmptyColumn()}
+                            {showEmptyHeader && this.buildEmptyColumn()}
                         </div>
                         <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
                             {allColumns &&
                                 allColumns.map((column: DataGridColumn, index: number) => {
-                                    return column.isVisible ? this.buildDataGridColumn(column, index) : undefined;
+                                    // Hide all columns except first visible column if detail pane is open
+                                    const showColumn =
+                                        this.isDetailPaneOpen() &&
+                                        column.columnID !== this.getFirstVisibleColumn()!.columnID
+                                            ? false
+                                            : column.isVisible;
+                                    return showColumn ? this.buildDataGridColumn(column, index) : undefined;
                                 })}
                         </div>
                     </div>
@@ -1020,9 +1181,13 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // function to build datagrid rows
     private buildDataGridRow(row: DataGridRow, index: number): React.ReactElement {
-        const {selectionType, rowType} = this.props;
-        const {rowData, className, style, isSelected, disableRowSelection} = row;
-        const isExpandableRow: boolean = rowType ? rowType === GridRowType.EXPANDABLE : false;
+        const {rowType} = this.props;
+        const {className, style, isSelected, disableRowSelection, detailPaneData} = row;
+        const isExpandableRow: boolean = rowType
+            ? rowType === GridRowType.EXPANDABLE || rowType === GridRowType.EXPANDABLE_ROWS_WITH_DETAIL_PANE
+            : false;
+        const isRowWithDetailPane: boolean = (row && row.detailPaneData && this.isDatagridWithDetailPane()) || false;
+
         let rowStyle = style;
         if (index === 0) {
             rowStyle = {...style, borderTop: "none"};
@@ -1034,43 +1199,63 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     ClassNames.DATAGRID_ROW,
                     ClassNames.DATAGRID_NG_STAR_INSERTED,
                     !disableRowSelection && isSelected && ClassNames.DATAGRID_SELECTED,
+                    isRowWithDetailPane &&
+                        detailPaneData &&
+                        detailPaneData.isOpen &&
+                        ClassNames.DATAGRID_ROW_DETAIL_OPEN,
                     className,
                 ])}
                 aria-owns={"clr-dg-row" + index}
                 style={rowStyle}
                 key={"row-" + index}
             >
-                <div
-                    className={classNames([
-                        `ng-tns-c96-${index}`,
-                        isExpandableRow && ClassNames.DATAGRID_EXPAND_ANIMATION,
-                    ])}
-                >
+                {isExpandableRow ? (
                     <div
-                        className={classNames([ClassNames.DATAGRID_ROW_MASTER, ClassNames.DATAGRID_NG_STAR_INSERTED])}
-                        role="row"
+                        className={classNames([
+                            `ng-tns-c96-${index}`,
+                            isExpandableRow && ClassNames.DATAGRID_EXPAND_ANIMATION,
+                        ])}
                     >
-                        <div className={ClassNames.DATAGRID_ROW_STICKY}>
-                            {selectionType && this.buildSelectCell(row)}
-                            {isExpandableRow && this.buildExpandableCell(row)}
-                        </div>
-                        <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
-                            <div className={ClassNames.DATAGRID_SCROLLING_CELLS}>
-                                {rowData &&
-                                    rowData.map((cell: any, index: number) => {
-                                        return this.buildDataGridCell(
-                                            cell.cellData,
-                                            index,
-                                            cell.columnName,
-                                            cell.className,
-                                            cell.style,
-                                        );
-                                    })}
-                            </div>
-                            {/* //Insert Expandable item view */}
-                            {isExpandableRow && this.buildExpandableRow(row)}
-                        </div>
+                        {this.buildRowCells(row, isExpandableRow, isRowWithDetailPane)}
                     </div>
+                ) : (
+                    this.buildRowCells(row, isExpandableRow, isRowWithDetailPane)
+                )}
+            </div>
+        );
+    }
+
+    // Function to build cells of single row
+    private buildRowCells(row: DataGridRow, isExpandableRow: boolean, isRowWithDetailPane: boolean) {
+        const {rowData} = row;
+        const {selectionType} = this.props;
+        return (
+            <div
+                className={classNames([ClassNames.DATAGRID_ROW_MASTER, ClassNames.DATAGRID_NG_STAR_INSERTED])}
+                role="row"
+            >
+                <div className={ClassNames.DATAGRID_ROW_STICKY}>
+                    {selectionType && this.buildSelectCell(row)}
+                    {isExpandableRow && this.buildExpandableCell(row)}
+                    {isRowWithDetailPane && this.buildDetailPaneToggleIcon(row)}
+                </div>
+                <div className={ClassNames.DATAGRID_ROW_SCROLLABLE}>
+                    <div className={ClassNames.DATAGRID_SCROLLING_CELLS}>
+                        <div className={ClassNames.DATAGRID_NG_STAR_INSERTED} />
+                        <div className={ClassNames.DATAGRID_NG_STAR_INSERTED} />
+                        {rowData &&
+                            rowData.map((cell: any, index: number) => {
+                                return this.buildDataGridCell(
+                                    cell.cellData,
+                                    index,
+                                    cell.columnName,
+                                    cell.className,
+                                    cell.style,
+                                );
+                            })}
+                    </div>
+                    {/* //Insert Expandable item view */}
+                    {isExpandableRow && this.buildExpandableRow(row)}
                 </div>
             </div>
         );
@@ -1096,6 +1281,85 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 )}
             </React.Fragment>
         );
+    }
+
+    // Function to build detail pane DOM for row
+    private buildDetailPaneForRow() {
+        const row: DataGridRow | undefined = this.getRowDataWithOpenDetailPane();
+        if (row) {
+            const rowID = row.rowID;
+            const {title, detailPaneContent, isOpen} = row.detailPaneData
+                ? row.detailPaneData
+                : {
+                      title: undefined,
+                      detailPaneContent: undefined,
+                      isOpen: false,
+                  };
+            const showDetailPane: boolean = isOpen && detailPaneContent;
+
+            return (
+                <React.Fragment>
+                    {showDetailPane && (
+                        <div
+                            className={classNames([
+                                ClassNames.DATAGRID_DETAIL_PANE,
+                                ClassNames.DATAGRID_NG_STAR_INSERTED,
+                            ])}
+                        >
+                            <span
+                                tabIndex={0}
+                                className={classNames([
+                                    ClassNames.OFFSCREEN_FOCUS_REBOUNDER,
+                                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                                ])}
+                            />
+                            <div
+                                role="dialog"
+                                aria-modal="true"
+                                className={classNames([
+                                    ClassNames.DATAGRID_DETAIL_PANE_CONTENT,
+                                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                                ])}
+                                id={`${"clr-id-"}-${rowID}`}
+                                aria-describedby={`clr-id-${rowID}-title`}
+                                tabIndex={-1}
+                            >
+                                <div className={ClassNames.CLR_SR_ONLY} />
+                                <div className={ClassNames.DATAGRID_DETAIL_HEADER}>
+                                    <div
+                                        className={ClassNames.DATAGRID_DETAIL_HEADER_TITLE}
+                                        id={`clr-id-${rowID}-title`}
+                                    >
+                                        {title}
+                                    </div>
+                                    <div className={ClassNames.DATAGRID_DETAIL_PANE_CLOSE}>
+                                        <Button
+                                            aria-label="Close"
+                                            className={ClassNames.PAGINATION_NEXT}
+                                            icon={{shape: "close"}}
+                                            onClick={() => rowID !== undefined && this.handleDetailPaneToggle(rowID)}
+                                        />
+                                    </div>
+                                </div>
+                                {/* close header*/}
+                                <div className={ClassNames.DATAGRID_DETAIL_BODY}>
+                                    <div className={ClassNames.CLR_DG_DETAIL_BODY_WRAPPER}> {detailPaneContent} </div>
+                                </div>
+                                {/* close body */}
+                                <div className={ClassNames.CLR_SR_ONLY} />
+                            </div>
+                            <span
+                                tabIndex={0}
+                                className={classNames([
+                                    ClassNames.OFFSCREEN_FOCUS_REBOUNDER,
+                                    ClassNames.DATAGRID_NG_STAR_INSERTED,
+                                ])}
+                            />
+                        </div>
+                    )}
+                </React.Fragment>
+            );
+        }
     }
 
     // function to build datagrid cell
@@ -1232,11 +1496,12 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private buildDataGridPagination(): React.ReactElement {
         const {className, style, compactFooter} = this.props.pagination!;
         const {itemText} = this.state;
+        const showCompactFooter: boolean = compactFooter || this.isDetailPaneOpen();
         let {totalItems, firstItem, lastItem, pageSize, pageSizes} = this.state.pagination!;
         if (totalItems === 0) {
             firstItem = lastItem = 0;
         }
-        const paginationLabel = compactFooter
+        const paginationLabel = showCompactFooter
             ? firstItem + "-" + lastItem + " / " + totalItems
             : firstItem + "-" + lastItem + " of " + totalItems + " " + itemText;
 
@@ -1246,9 +1511,9 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 style={style}
                 className={classNames([ClassNames.DATAGRID_PAGINATION, className])}
             >
-                {!compactFooter && pageSizes && totalItems >= pageSize && this.buildPageSizesSelect()}
+                {!showCompactFooter && pageSizes && totalItems >= pageSize && this.buildPageSizesSelect()}
 
-                {compactFooter ? (
+                {showCompactFooter ? (
                     <div className={ClassNames.DATAGRID_NG_STAR_INSERTED} style={Styles.PAGINATION_DESCRIPTION_COMPACT}>
                         {paginationLabel}
                     </div>
@@ -1256,7 +1521,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     <div className={classNames([ClassNames.PAGINATION_DESC])}>{paginationLabel}</div>
                 )}
 
-                {compactFooter ? this.buildCompactPageButtons() : this.buildPageButtons()}
+                {showCompactFooter ? this.buildCompactPageButtons() : this.buildPageButtons()}
             </div>
         );
     }
@@ -1316,6 +1581,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 {footer &&
                     footer.hideShowColumns &&
                     footer.hideShowColumns.hideShowColBtn &&
+                    !this.isDetailPaneOpen() &&
                     this.buildHideShowColumnsBtn()}
 
                 {this.buildSelectedRowCount()}
@@ -1339,12 +1605,18 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     render() {
         const {className, style, rowType, footer, dataqa, isLoading} = this.props;
         const isDataLoading: boolean = isLoading !== undefined ? isLoading : this.state.isLoading;
+        const isDetailPaneOpen: boolean = this.isDetailPaneOpen();
+        const isCompactDatagrid: boolean =
+            (rowType && rowType === GridRowType.COMPACT) || rowType === GridRowType.COMPACT_ROWS_WITH_DETAIL_PANE
+                ? true
+                : false;
 
         return (
             <div
                 className={classNames([
                     ClassNames.DATAGRID_HOST, // prettier
-                    rowType === GridRowType.COMPACT && ClassNames.DATAGRID_COMPACT,
+                    isCompactDatagrid && ClassNames.DATAGRID_COMPACT,
+                    isDetailPaneOpen && ClassNames.DATAGRID_DETAIL_OPEN,
                     className,
                 ])}
                 style={style}
@@ -1354,11 +1626,12 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     <div className={ClassNames.DATAGRID_INNER_WRAPPER}>
                         {this.buildDataGridBody()}
                         {footer && footer.showFooter && this.buildDataGridFooter()}
-                        <div className={ClassNames.DATAGRID_CAL_TABLE}>
-                            <div className={ClassNames.DATAGRID_CAL_HEADER} />
-                        </div>
                         {isDataLoading && this.buildDataGridSpinner()}
                     </div>
+                    {isDetailPaneOpen && this.buildDetailPaneForRow()}
+                </div>
+                <div className={ClassNames.DATAGRID_CAL_TABLE}>
+                    <div className={ClassNames.DATAGRID_CAL_HEADER} />
                 </div>
             </div>
         );

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -144,6 +144,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
                 // Update datagrid rows
                 const {rows, totalItems} = data;
                 datagridRef.current!.updateRows(rows, totalItems);
+                datagridRef.current!.closeDetailPane();
                 datagridRef.current!.hideLoader();
             });
         }

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import {Icon} from "../icon";
 import {Button} from "../forms/button";
 import {SortOrder, DataGridRow, DataGridFilterResult, DataGridColumn, DataGridCell} from ".";
+import {Password} from "../forms/password/Password";
 
 /**
  * General file description :
@@ -120,6 +121,51 @@ export const customRows = [
     },
 ];
 
+export const customRowsWithPassword = [
+    {
+        rowData: [
+            {columnName: "User ID", cellData: 41512},
+            {columnName: "Name", cellData: "Georgia"},
+            {columnName: "Creation Date", cellData: "Sep 11, 2008"},
+            {
+                columnName: "Favorite color",
+                cellData: (
+                    <div style={{marginTop: "-35px"}}>
+                        <Password
+                            name="Password"
+                            value="Georgia-pass"
+                            minPasswordLength={8}
+                            readOnly={true}
+                            style={{border: "none"}}
+                        />
+                    </div>
+                ),
+            },
+        ],
+    },
+    {
+        rowData: [
+            {columnName: "User ID", cellData: 16166},
+            {columnName: "Name", cellData: "Brynn"},
+            {columnName: "Creation Date", cellData: "Aug 2, 2014"},
+            {
+                columnName: "Favorite color",
+                cellData: (
+                    <div style={{marginTop: "-35px"}}>
+                        <Password
+                            name="Password"
+                            value="Brynn-pass"
+                            minPasswordLength={8}
+                            readOnly={true}
+                            style={{border: "none"}}
+                        />
+                    </div>
+                ),
+            },
+        ],
+    },
+];
+
 /**
  * Data for Expandable Rows
  */
@@ -184,6 +230,69 @@ export const expandableRows: DataGridRow[] = [
     },
 ];
 
+const DetailPane: React.ReactElement = (
+    <React.Fragment>
+        <b>Additional Details</b>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>ID</td>
+                    <td>38808</td>
+                </tr>
+                <tr>
+                    <td>Wins</td>
+                    <td>69</td>
+                </tr>
+            </tbody>
+        </table>
+    </React.Fragment>
+);
+
+// Rows with detail pane
+export function getRowsWithDetailPane() {
+    let rowValues: DataGridRow[] = [];
+    cellData.forEach(function(element: any) {
+        const row: DataGridRow = {
+            rowData: [
+                {
+                    columnName: "User ID",
+                    cellData: element[0],
+                },
+                {
+                    columnName: "Name",
+                    cellData: element[1],
+                },
+                {
+                    columnName: "Creation Date",
+                    cellData: element[2],
+                },
+                {
+                    columnName: "Favorite color",
+                    cellData: element[3],
+                },
+            ],
+            detailPaneData: {
+                detailPaneContent: DetailPane,
+                title: element[1],
+            },
+            expandableRowData: {
+                expandableContent: expandableContent,
+            },
+        };
+        rowValues.push(row);
+    });
+    return rowValues;
+}
+
+export const rowsWithDetailPane = getRowsWithDetailPane();
+
+// Function to get row data
 export function getRowData() {
     let rowValues: DataGridRow[] = [];
     cellData.forEach(function(element: any) {
@@ -407,6 +516,7 @@ export const getPageData = (pageIndex: number, pageSize: number): Promise<DataGr
         }, 2000);
     });
 };
+
 // Function to get data for page based on pagenumber
 export const getPageDataForSelectedRows = (pageIndex: number, pageSize: number): Promise<DataGridRow[]> => {
     return new Promise((resolve, reject) => {
@@ -428,6 +538,29 @@ export const getPageDataForSelectedRows = (pageIndex: number, pageSize: number):
         }, 2000);
     });
 };
+
+// Function to get data for page based on pagenumber
+export const getPageDataForDetailPane = (pageIndex: number, pageSize: number): Promise<DataGridRow[]> => {
+    return new Promise((resolve, reject) => {
+        let rows: DataGridRow[] = [];
+        if (pageSize === 5) {
+            if (pageIndex === 2) {
+                rows = rowsWithDetailPane.slice(5, 10);
+            }
+            if (pageIndex === 1) {
+                rows = rowsWithDetailPane.slice(0, 5);
+            }
+        } else if (pageSize === 10) {
+            rows = rowsWithDetailPane;
+        }
+
+        // Purposefully added dealy here to see loading spinner
+        setTimeout(function() {
+            resolve(rows);
+        }, 2000);
+    });
+};
+
 export const paginationDetails = {
     totalItems: paginationRows.length,
     getPageData: getPageData,
@@ -446,6 +579,13 @@ export const paginationDetailsWithCompactFooter = {
 export const paginationDetailsForAlreadySelectedRows = {
     totalItems: alreadySelectedRows.length,
     getPageData: getPageDataForSelectedRows,
+    pageSize: 5,
+    pageSizes: [5, 10],
+};
+
+export const paginationDetailsForDetailsPane = {
+    totalItems: rowsWithDetailPane.length,
+    getPageData: getPageDataForDetailPane,
     pageSize: 5,
     pageSizes: [5, 10],
 };

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -354,11 +354,7 @@ export function getRowDataWithLink(functionToAttach: Function) {
                 },
             ],
             detailPaneData: {
-                detailPaneContent: (
-                    <div style={{border: "1px solid grey", width: "500px", height: "300px"}}>
-                        Details Panel for : {element[1]}
-                    </div>
-                ),
+                detailPaneContent: <React.Fragment>Details Panel for : {element[1]}</React.Fragment>,
             },
         };
 

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -322,6 +322,51 @@ export function getRowData() {
     return rowValues;
 }
 
+export function getRowDataWithLink(functionToAttach: Function) {
+    let rowValues: DataGridRow[] = [];
+    cellData.forEach(function(element: any, index: number) {
+        const row: DataGridRow = {
+            rowData: [
+                {
+                    columnName: "User ID",
+                    cellData: element[0],
+                },
+                {
+                    columnName: "Name",
+                    cellData: (
+                        // eslint-disable-next-line
+                        <a
+                            href="javascript:void(0);" // eslint-disable-line no-script-url
+                            className="nameLink"
+                            onClick={event => functionToAttach(index)}
+                        >
+                            {element[1]}
+                        </a>
+                    ),
+                },
+                {
+                    columnName: "Creation Date",
+                    cellData: element[2],
+                },
+                {
+                    columnName: "Favorite color",
+                    cellData: element[3],
+                },
+            ],
+            detailPaneData: {
+                detailPaneContent: (
+                    <div style={{border: "1px solid grey", width: "500px", height: "300px"}}>
+                        Details Panel for : {element[1]}
+                    </div>
+                ),
+            },
+        };
+
+        rowValues.push(row);
+    });
+    return rowValues;
+}
+
 // Function to get some selection enabled rows
 export const getSelectableRowsData = (): DataGridRow[] => {
     let disableRowSelection: boolean = true;
@@ -346,6 +391,9 @@ export const getSelectedRowsData = (): DataGridRow[] => {
 
 // Data for pagination rows
 export const paginationRows = getRowData();
+
+// Data for pagination rows
+export const paginationRowsWithLinks = (linkFunction: Function) => getRowDataWithLink(linkFunction);
 
 // Data for pre-selected rows
 export const alreadySelectedRows = getSelectedRowsData();

--- a/src/datagrid/HideShowColumns.tsx
+++ b/src/datagrid/HideShowColumns.tsx
@@ -154,7 +154,7 @@ export class HideShowColumns extends React.PureComponent<HideShowColumnsProps, H
     // function to build column list
     private buildColumnList(column: DataGridColumn, index: number): React.ReactElement {
         return (
-            <li>
+            <li key={index}>
                 <div className={ClassNames.CLR_CHECKBOX_WRAPPER} key={"selectCol_" + index}>
                     <CheckBox
                         id={column.columnName}

--- a/src/forms/button/Button.stories.tsx
+++ b/src/forms/button/Button.stories.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import {storiesOf} from "@storybook/react";
 import {action} from "@storybook/addon-actions";
 import {Button, ButtonSize, ButtonState} from ".";
+import {Badge, BadgeColor} from "../../emphasis/badges";
 
 storiesOf("Button", module)
     .add("Simple buttons", () => (
@@ -139,6 +140,46 @@ storiesOf("Button", module)
             </Button>
             <Button key="basic" defaultBtn={false} onClick={action("basic click")}>
                 BASIC
+            </Button>
+        </div>
+    ))
+    .add("Buttons with badge", () => (
+        <div>
+            <Button key="basic" onClick={action("basic click")}>
+                BASIC
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge color={BadgeColor.LIGHT_BLUE}>1</Badge>
+                </span>
+            </Button>
+            <Button key="basic-info" state={ButtonState.INFO} onClick={action("basic-info click")}>
+                INFO
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge color={BadgeColor.LIGHT_BLUE}> 2 </Badge>
+                </span>
+            </Button>
+            <Button key="basic-warning" state={ButtonState.WARNING} onClick={action("basic-warning click")}>
+                WARNING
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge color={BadgeColor.BLUE}> 3 </Badge>
+                </span>
+            </Button>
+            <Button key="basic-success" state={ButtonState.SUCCESS} onClick={action("basic-success click")}>
+                SUCCESS
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge color={BadgeColor.ORANGE}> 4 </Badge>
+                </span>
+            </Button>
+            <Button key="basic-danger" state={ButtonState.DANGER} onClick={action("basic-danger click")}>
+                DANGER
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge color={BadgeColor.ORANGE}> 5 </Badge>
+                </span>
+            </Button>
+            <Button key="basic-disabled" disabled={true} onClick={action("basic-disabled click")}>
+                DISABLED
+                <span style={{paddingLeft: "0.5rem"}}>
+                    <Badge> 6 </Badge>
+                </span>
             </Button>
         </div>
     ));

--- a/src/forms/password/Password.stories.tsx
+++ b/src/forms/password/Password.stories.tsx
@@ -63,4 +63,7 @@ storiesOf("Password", module)
             placeholder="Numeric password"
             title={"Numeric password"}
         />
+    ))
+    .add("Password box with read-only value", () => (
+        <Password name="Password" value="Georgia-pass" readOnly={true} style={{border: "none", width: "10%"}} />
     ));

--- a/src/forms/password/Password.tsx
+++ b/src/forms/password/Password.tsx
@@ -39,6 +39,7 @@ type PasswordProps = {
     unmask?: boolean; // if true renders eye icon to hide/show or mask/unmask password
     pattern?: string; // specifies a regular expression that element's value is checked against
     dataqa?: string; //quality engineering testing field
+    readOnly?: boolean; //specifies if password is readonly
 };
 
 type PasswordState = {
@@ -103,6 +104,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
             unmask,
             pattern,
             dataqa,
+            readOnly,
         } = this.props;
 
         const {show, type} = this.state;
@@ -136,6 +138,7 @@ export class Password extends React.PureComponent<PasswordProps, PasswordState> 
                                     pattern={pattern}
                                     data-qa={dataqa}
                                     onChange={this.handleChange}
+                                    readOnly={readOnly}
                                 />
 
                                 {unmask && (

--- a/src/forms/radio/RadioButton.tsx
+++ b/src/forms/radio/RadioButton.tsx
@@ -30,7 +30,7 @@ type RadioButtonProps = {
     checked?: boolean;
     className?: string;
     disabled?: boolean;
-    label?: string;
+    label?: any;
     labelClass?: string;
     onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
     name?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,15 +1806,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@clr/icons@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-3.0.0.tgz#d8faa0b9c8d33a48db8db6e422d1e7c1b343d84f"
-  integrity sha512-3gNVHjze/+uGafyLWZ7mEQbkI24VAnOJoUZTn7XMir7FYbuxIutunUYP0XbK3A5j/F/8LtfEc1g6ArVa9is2xA==
+"@clr/icons@4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-4.0.8.tgz#3ca645ff7eaeb25db6f5cd35ccf55f06f92c4c28"
+  integrity sha512-zrr47GgmK+AhM6yHG1GwXn8rsqpdnJVtr6NaJP8CMDfpwq+GvJY0JB8XNPE/d/Ujg8/RQeKwVYzsqmUltBSzoQ==
 
-"@clr/ui@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-3.0.0.tgz#8fc5dea32f2077609a9d005632870d9af9d1a10f"
-  integrity sha512-XUHSAoSu1jnlGn2V4cF/fp05TZixfKgV89dqmOYxPNbHbm1u/ozTHmFvd4N7HO8HgBjki+t5YYBz6YGXlq1pRA==
+"@clr/ui@4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-4.0.8.tgz#1d0963090ce3389fda6483f33ec9cf3c68c1506d"
+  integrity sha512-0nAQ+x4ozG7ErW7Oa2OLrS9AkSyc9fZG6PWxpJoyVRTuB38fF3nORWvAeabHq9OLus3VhRO+yzbJCjxIPFHjRg==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
We already have the reference of Datagrid used in parent components.  So leveraging that mechanism to toggle the details panel from outside.  First usecase is to support the Object Store Name click opens Details panel. 

Also added the entry in .gitignore to ignore the storybook-static content from checkins.

Added storybook to demo this behaviour.  The Details panel open and close happens on both Link Click and Button Click as well.

**When Details Panel is not Open**
![image](https://user-images.githubusercontent.com/54625112/107018474-614c1c80-6798-11eb-9306-c70a59052bca.png)


**When Details panel is opened**
![image](https://user-images.githubusercontent.com/54625112/107018510-6e690b80-6798-11eb-8099-fed826c2a25d.png)


