### PR TITLE
Feature [OBSDEF-5812] - debounce behaviour enhacements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.25.4",
+    "version": "0.25.5",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.25.5",
+    "version": "0.25.6",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/forms/common/DebounceUtils.ts
+++ b/src/forms/common/DebounceUtils.ts
@@ -9,7 +9,7 @@
  */
 
 const defaultDebounce = 500; // miliseconds
-const DebounceDisabled = "false";
+const DebounceDisabled: boolean = false;
 
 export class DebounceUtils {
     debounceTimer: any = null;
@@ -18,12 +18,13 @@ export class DebounceUtils {
      * This method only suports the debounce with Events
      * @param evt - SyntheticEvent Event which is input to the called function
      * @param func - Function to be applied post debouce time is over
+     * @param debounce - Boolean value to decide if debounce is needed or not
      * @param debounceTime - optional debounceTime in miliseconds, defaultDebounce will be used if not provided
      */
     public debounce = (
         evt: React.SyntheticEvent,
         func: Function | undefined,
-        debounce?: string,
+        debounce?: boolean,
         debounceTime?: number,
     ) => {
         // if function passed is not set by parent
@@ -43,23 +44,6 @@ export class DebounceUtils {
         evt.persist();
         const triggerFunction = (evt: any) => {
             func.apply(this, [evt]);
-        };
-
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = setTimeout(() => triggerFunction(evt), waitTime);
-    };
-
-    public debounce1 = (evt: React.SyntheticEvent, func: Function | undefined, debounceTime: number | undefined) => {
-        // if function passed is not set by parent
-        if (!func) {
-            return func;
-        }
-        const waitTime = debounceTime || defaultDebounce;
-
-        // this is needed to retain the Synthetic events
-        evt.persist();
-        const triggerFunction = (evt: any) => {
-            func.apply(null, [evt]);
         };
 
         clearTimeout(this.debounceTimer);

--- a/src/forms/common/DebounceUtils.ts
+++ b/src/forms/common/DebounceUtils.ts
@@ -9,6 +9,7 @@
  */
 
 const defaultDebounce = 500; // miliseconds
+const DebounceDisabled = "false";
 
 export class DebounceUtils {
     debounceTimer: any = null;
@@ -19,7 +20,36 @@ export class DebounceUtils {
      * @param func - Function to be applied post debouce time is over
      * @param debounceTime - optional debounceTime in miliseconds, defaultDebounce will be used if not provided
      */
-    public debounce = (evt: React.SyntheticEvent, func: Function | undefined, debounceTime: number | undefined) => {
+    public debounce = (
+        evt: React.SyntheticEvent,
+        func: Function | undefined,
+        debounce?: string,
+        debounceTime?: number,
+    ) => {
+        // if function passed is not set by parent
+        if (!func) {
+            return func;
+        }
+
+        // if debounce option is disabled
+        if (debounce === DebounceDisabled) {
+            func.apply(this, [evt]);
+            return;
+        }
+
+        const waitTime = debounceTime || defaultDebounce;
+
+        // this is needed to retain the Synthetic events
+        evt.persist();
+        const triggerFunction = (evt: any) => {
+            func.apply(this, [evt]);
+        };
+
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = setTimeout(() => triggerFunction(evt), waitTime);
+    };
+
+    public debounce1 = (evt: React.SyntheticEvent, func: Function | undefined, debounceTime: number | undefined) => {
         // if function passed is not set by parent
         if (!func) {
             return func;

--- a/src/forms/datalist/DataList.stories.tsx
+++ b/src/forms/datalist/DataList.stories.tsx
@@ -91,7 +91,8 @@ storiesOf("DataList", module)
                 helperText="Select any option or create one"
                 label="Select Item"
                 onChange={action("changed: after 5 secs", new Date().toLocaleTimeString())}
-                debounceTime={5000}
+                debounce={true}
+                debounceTime={1000}
             >
                 <DataListOption value="Item1" />
                 <DataListOption value="Item2" />

--- a/src/forms/datalist/DataList.tsx
+++ b/src/forms/datalist/DataList.tsx
@@ -104,7 +104,8 @@ type DataListProps = {
     style?: any;
     defaultValue?: string;
     spellCheck?: boolean;
-    debounceTime?: number; //debounce time in miliseconds
+    debounce?: boolean; // decide if debounce is needed or not
+    debounceTime?: number; // debounce time in miliseconds
 };
 
 /**
@@ -171,6 +172,7 @@ export class DataList extends React.PureComponent<DataListProps, DataListState> 
             autoComplete,
             defaultValue,
             spellCheck,
+            debounce,
             debounceTime,
         } = this.props;
 
@@ -192,7 +194,7 @@ export class DataList extends React.PureComponent<DataListProps, DataListState> 
                                 onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}
                                 onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
-                                    debounceOnChange.debounce(evt, onChange, debounceTime)
+                                    debounceOnChange.debounce(evt, onChange, debounce, debounceTime)
                                 }
                                 placeholder={placeHolder}
                                 name={name}

--- a/src/forms/input/Input.stories.tsx
+++ b/src/forms/input/Input.stories.tsx
@@ -16,11 +16,11 @@ import {Icon} from "../../icon";
 
 // onChange handler
 const handleEvent = (evt: any) => {
-    return action(
-        `[new Date().toLocaleTimeString()] - evet triggered: ${evt && evt.type}, event value: ${evt &&
-            evt.target &&
-            evt.target.value}`,
-    );
+    const message = `[${new Date().toLocaleTimeString()}] - 'Event Type': ${evt && evt.type}, 'Event Value': ${evt &&
+        evt.target &&
+        evt.target.value}`;
+    // while calling from outside, the action need to be called explicitely.
+    action(message)();
 };
 
 storiesOf("Input", module)
@@ -114,10 +114,11 @@ storiesOf("Input", module)
         return (
             <Input
                 name="somevalue"
-                onChange={action("changed: after 5 secs", new Date().toLocaleTimeString())}
+                onChange={handleEvent}
                 placeholder="input with title"
                 title={"Title for input"}
-                debounceTime={5000}
+                debounceTime={1000}
+                debounce={true}
             />
         );
     })
@@ -126,12 +127,12 @@ storiesOf("Input", module)
             <Input
                 type="number"
                 name="numberValue"
-                onChange={action(`[new Date().toLocaleTimeString()] - change event triggered`)}
-                onKeyDown={action(`[new Date().toLocaleTimeString()] - keyDown event triggered`)}
-                onKeyPress={action(`[new Date().toLocaleTimeString()] - keyPress event triggered`)}
+                onChange={handleEvent}
+                onKeyDown={handleEvent}
+                onKeyPress={handleEvent}
                 placeholder="Input with type Number"
                 title={"Title for input (type Number)"}
-                debounce={"false"}
+                debounce={false}
             />
         );
     })
@@ -141,13 +142,13 @@ storiesOf("Input", module)
             <Input
                 type="number"
                 name="numberValue"
-                onChange={action(`[new Date().toLocaleTimeString()] - change event triggered`)}
-                onKeyDown={action(`[new Date().toLocaleTimeString()] - keyDown event triggered`)}
-                onKeyPress={action(`[new Date().toLocaleTimeString()] - keyPress event triggered`)}
+                onChange={handleEvent}
+                onKeyDown={handleEvent}
+                onKeyPress={handleEvent}
                 placeholder="Input with type Number"
                 title={"Title for input (type Number)"}
-                // debounceTime={1000}
-                // debounce={"true"}
+                debounceTime={1000}
+                debounce={true}
             />
         );
     });

--- a/src/forms/input/Input.stories.tsx
+++ b/src/forms/input/Input.stories.tsx
@@ -14,6 +14,15 @@ import {action} from "@storybook/addon-actions";
 import {Input} from "./Input";
 import {Icon} from "../../icon";
 
+// onChange handler
+const handleEvent = (evt: any) => {
+    return action(
+        `[new Date().toLocaleTimeString()] - evet triggered: ${evt && evt.type}, event value: ${evt &&
+            evt.target &&
+            evt.target.value}`,
+    );
+};
+
 storiesOf("Input", module)
     .add("a simple input box", () => <Input name="somevalue" onChange={action("changed")} />)
     .add("a simple input box with value", () => <Input name="somevalue" value="Apple" onChange={action("changed")} />)
@@ -109,6 +118,36 @@ storiesOf("Input", module)
                 placeholder="input with title"
                 title={"Title for input"}
                 debounceTime={5000}
+            />
+        );
+    })
+    .add("input type number with Debounce behaviour off", () => {
+        return (
+            <Input
+                type="number"
+                name="numberValue"
+                onChange={action(`[new Date().toLocaleTimeString()] - change event triggered`)}
+                onKeyDown={action(`[new Date().toLocaleTimeString()] - keyDown event triggered`)}
+                onKeyPress={action(`[new Date().toLocaleTimeString()] - keyPress event triggered`)}
+                placeholder="Input with type Number"
+                title={"Title for input (type Number)"}
+                debounce={"false"}
+            />
+        );
+    })
+
+    .add("input type number with Debounce behaviour ON", () => {
+        return (
+            <Input
+                type="number"
+                name="numberValue"
+                onChange={action(`[new Date().toLocaleTimeString()] - change event triggered`)}
+                onKeyDown={action(`[new Date().toLocaleTimeString()] - keyDown event triggered`)}
+                onKeyPress={action(`[new Date().toLocaleTimeString()] - keyPress event triggered`)}
+                placeholder="Input with type Number"
+                title={"Title for input (type Number)"}
+                // debounceTime={1000}
+                // debounce={"true"}
             />
         );
     });

--- a/src/forms/input/Input.tsx
+++ b/src/forms/input/Input.tsx
@@ -44,8 +44,8 @@ type InputProps = {
     required?: boolean; // auto-check on blur if there's a value
     error?: boolean; // force error state of component
     dataqa?: string; //quality engineering testing field
+    debounce?: boolean; // apply debounce behaviour or not
     debounceTime?: number; // debounceTime/Delay value in miliseconds
-    debounce?: string; // apply debounce behaviour or not
 };
 
 const initialState = {value: null};

--- a/src/forms/input/Input.tsx
+++ b/src/forms/input/Input.tsx
@@ -44,7 +44,8 @@ type InputProps = {
     required?: boolean; // auto-check on blur if there's a value
     error?: boolean; // force error state of component
     dataqa?: string; //quality engineering testing field
-    debounceTime?: number; // apply debounce behaviour and value provided is miliseconds of delay to be added
+    debounceTime?: number; // debounceTime/Delay value in miliseconds
+    debounce?: string; // apply debounce behaviour or not
 };
 
 const initialState = {value: null};
@@ -106,6 +107,7 @@ export class Input extends React.PureComponent<InputProps> {
             helperText,
             spellCheck,
             pattern,
+            debounce,
             debounceTime,
         } = this.props;
         return (
@@ -122,13 +124,13 @@ export class Input extends React.PureComponent<InputProps> {
                     placeholder={placeholder}
                     data-qa={dataqa}
                     onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
-                        this.debounceHandleChange.debounce(evt, this.handleChange, debounceTime)
+                        this.debounceHandleChange.debounce(evt, this.handleChange, debounce, debounceTime)
                     }
                     onKeyDown={(evt: React.KeyboardEvent<HTMLInputElement>) =>
-                        this.debounceHandleKeyDown.debounce(evt, this.handleKeyDown, debounceTime)
+                        this.debounceHandleKeyDown.debounce(evt, this.handleKeyDown, debounce, debounceTime)
                     }
                     onKeyPress={(evt: React.KeyboardEvent<HTMLInputElement>) =>
-                        this.debounceOnKeyPress.debounce(evt, onKeyPress, debounceTime)
+                        this.debounceOnKeyPress.debounce(evt, onKeyPress, debounce, debounceTime)
                     }
                     title={title}
                     onBlur={onBlur}


### PR DESCRIPTION
In 0.25.4 build, the debounce was made mandatory for all text fields. This had sideeffect on the Input with Type="number".  So in this PR, we have introduced one more Prop for **DataList** and **Input** components.
- debounce   ->  optional field, boolean. This need to be set to false if you dont want debounce on the input field
- debounceTime -> optional field, number. Default debounce Time is 500ms, if you want to change that time, then you can set these numbers. 

**Debounce Set False**
![Debounce-set-off-input-field-with-numbers](https://user-images.githubusercontent.com/54625112/107632423-7d662700-6c8c-11eb-8d26-2b55a6f7475b.gif)

**Debounce Set True - with 1 Second debounceTime ** 
![Debounce-set-on-input-field-numbers](https://user-images.githubusercontent.com/54625112/107632430-7f2fea80-6c8c-11eb-85af-df4cbfa02eae.gif)



