### PR TITLE
Added debounce feature to Filters and also added fix for clearing filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dell/clarity-react",
-    "version": "0.25.6",
+    "version": "0.25.8",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -13,6 +13,7 @@ import {classNames} from "../utils";
 import {ClassNames} from "./ClassNames";
 import {Button} from "../forms/button";
 import {DataGridRow} from "./DataGrid";
+import {DebounceUtils} from "../forms/common/DebounceUtils";
 
 /**
  * Props for DataGridFilter :
@@ -23,6 +24,7 @@ import {DataGridRow} from "./DataGrid";
  * @param {placeholder} placeholder for string filter input
  * @param {onFilter} Custom filter logic
  * @param {filterType} Type of filter string or custom
+ * @param {disabled} boolean value to enable or disable filter
  */
 export type DataGridFilterProps = {
     style?: any;
@@ -33,6 +35,7 @@ export type DataGridFilterProps = {
     onFilter: (rows: DataGridRow[], columnValue: any, columnName: string) => Promise<DataGridFilterResult>;
     filterType?: FilterType;
     showFilter?: boolean;
+    disabled?: boolean;
 };
 
 /**
@@ -59,10 +62,12 @@ export enum FilterType {
  * State for DataGridFilter:
  * @param {isOpen} check if filter box is open
  * @param {transformVal} value for transform css attribute
+ * @param {isFiltered} boolean value to indicate if filter is applied or not
  */
 type DataGridFilterState = {
     isOpen: boolean;
     transformVal: string;
+    isFiltered: boolean;
 };
 
 /**
@@ -84,7 +89,8 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     private refParent = React.createRef<HTMLDivElement>();
     private refChild = React.createRef<HTMLDivElement>();
     private filterValue: any;
-    private isFiltered: boolean;
+    //private isFiltered: boolean;
+    private debounceHandleChange: DebounceUtils = new DebounceUtils();
 
     static defaultProps = {
         filterType: FilterType.STR,
@@ -92,18 +98,19 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
         style: {},
         customFilter: null,
         showFilter: true,
+        disabled: false,
     };
 
     // Initial state for filter
     state: DataGridFilterState = {
         isOpen: false,
         transformVal: "translateX(0px) translateY(0px)",
+        isFiltered: false,
     };
 
     constructor(props: DataGridFilterProps) {
         super(props);
         this.filterValue = undefined;
-        this.isFiltered = false;
     }
 
     componentWillMount() {
@@ -129,6 +136,11 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
         }
     }
 
+    private handlOnChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+        const value: string = evt.target.value;
+        this.updateFilter(value);
+    };
+
     updateFilter = (value: any) => {
         const {columnName, datagridRef, onFilter} = this.props;
         datagridRef.current!.showLoader();
@@ -140,7 +152,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
 
         if (onFilter && datagridRef) {
             this.filterValue = value;
-            this.isFiltered = String(value).length !== 0;
+            this.setState({isFiltered: String(value).length !== 0});
 
             onFilter(rows, value, columnName).then(data => {
                 // Update datagrid rows
@@ -194,7 +206,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     private openFilter(): React.ReactElement {
         const {filterValue} = this;
         const {transformVal} = this.state;
-        const {style, className, filterType, placeholder, columnName, children} = this.props;
+        const {style, className, filterType, placeholder, columnName, children, disabled} = this.props;
 
         const childrenWithProps = React.Children.map(children, child => {
             // checking isValidElement is the safe way and avoids a typescript error too
@@ -237,9 +249,10 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
                             name={`name-${columnName}`}
                             placeholder={placeholder}
                             defaultValue={filterValue}
-                            onChange={evt => {
-                                this.updateFilter(evt.target.value);
-                            }}
+                            disabled={disabled || false}
+                            onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+                                this.debounceHandleChange.debounce(evt, this.handlOnChange, true)
+                            }
                         />
                     ) : (
                         filterType === FilterType.CUSTOM && childrenWithProps
@@ -251,9 +264,9 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     }
 
     render() {
-        const {isOpen} = this.state;
+        const {isOpen, isFiltered} = this.state;
         const {showFilter} = this.props;
-        const {isFiltered} = this;
+        //const {isFiltered} = this;
         const FilterBtnClasses = classNames([
             ClassNames.DATAGRID_FILTER_BUTTON,
             isFiltered && ClassNames.DATAGRID_FILTERED,

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -280,7 +280,6 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     render() {
         const {isOpen, isFiltered} = this.state;
         const {showFilter} = this.props;
-        //const {isFiltered} = this;
         const FilterBtnClasses = classNames([
             ClassNames.DATAGRID_FILTER_BUTTON,
             isFiltered && ClassNames.DATAGRID_FILTERED,

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -93,7 +93,6 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     private refParent = React.createRef<HTMLDivElement>();
     private refChild = React.createRef<HTMLDivElement>();
     private filterValue: any;
-    //private isFiltered: boolean;
     private debounceHandleChange: DebounceUtils = new DebounceUtils();
 
     static defaultProps = {

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -25,6 +25,8 @@ import {DebounceUtils} from "../forms/common/DebounceUtils";
  * @param {onFilter} Custom filter logic
  * @param {filterType} Type of filter string or custom
  * @param {disabled} boolean value to enable or disable filter
+ * @param {debounce} boolean value to apply debounce behaviour
+ * @param {debounceTime} number value debounceTime/Delay value in miliseconds
  */
 export type DataGridFilterProps = {
     style?: any;
@@ -36,6 +38,8 @@ export type DataGridFilterProps = {
     filterType?: FilterType;
     showFilter?: boolean;
     disabled?: boolean;
+    debounce?: boolean;
+    debounceTime?: number;
 };
 
 /**
@@ -136,12 +140,12 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
         }
     }
 
-    private handlOnChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    private handleOnChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
         const value: string = evt.target.value;
         this.updateFilter(value);
     };
 
-    updateFilter = (value: any) => {
+    public updateFilter = (value: any) => {
         const {columnName, datagridRef, onFilter} = this.props;
         datagridRef.current!.showLoader();
 
@@ -206,7 +210,17 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
     private openFilter(): React.ReactElement {
         const {filterValue} = this;
         const {transformVal} = this.state;
-        const {style, className, filterType, placeholder, columnName, children, disabled} = this.props;
+        const {
+            style,
+            className,
+            filterType,
+            placeholder,
+            columnName,
+            children,
+            disabled,
+            debounce,
+            debounceTime,
+        } = this.props;
 
         const childrenWithProps = React.Children.map(children, child => {
             // checking isValidElement is the safe way and avoids a typescript error too
@@ -251,7 +265,7 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
                             defaultValue={filterValue}
                             disabled={disabled || false}
                             onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
-                                this.debounceHandleChange.debounce(evt, this.handlOnChange, true)
+                                this.debounceHandleChange.debounce(evt, this.handleOnChange, debounce, debounceTime)
                             }
                         />
                     ) : (


### PR DESCRIPTION
https://jira.cec.lab.emc.com/browse/OBSDEF-4746

1) Added Debounce of 500ms

Filters on ObjectStoreList, events, issues pages fires too many backend calls, as every keystroke fires one backend call. This is not really performant, so to reduce this behaviour we have added debounce with 500ms to all the text based filters.

2) DataGridFilter didnt had option to clear themself, so exposed a method to clear the dataGrid Filter by passing Empty string

3) Introducted **disabled** prop to allow disabling filter textbox if the props is applied. This is important to avoid user typing into the textbox when some backend calls are already in progress and loader is visible.  In current implementation, the DataGrid Loader does not block user from keep typing into filter.  So this disabled prop would help solve this issue.