### PR TITLE
[OBSDEF-7469] Added prop for disabling previous button

### DIFF
--- a/src/newWizard/Wizard.stories.tsx
+++ b/src/newWizard/Wizard.stories.tsx
@@ -32,16 +32,7 @@ function buildStepData(numberOfSteps: number = 1) {
 // Function to create steps UI
 function buildStepsUI() {
     const StepUI = steps.map((step, index) => {
-        return (
-            <WizardStep
-                id={index}
-                key={index}
-                name={step.name}
-                type={step.type}
-                valid={true}
-                complete={true}
-            ></WizardStep>
-        );
+        return <WizardStep id={index} key={index} name={step.name} type={step.type} valid={true} complete={true} />;
     });
     return StepUI;
 }
@@ -327,6 +318,38 @@ storiesOf("New Wizard", module)
                         onPrevious={() => state.handlePrevious()}
                         onComplete={() => state.handleComplete()}
                         onNavigateTo={state.handleSelectStep}
+                        customFooter={(props: WizardFooterProps) => (
+                            <Button primary link onClick={() => state.removeStep(state.currentWizardStepID)}>
+                                Delete Step
+                            </Button>
+                        )}
+                    >
+                        {state.steps}
+                    </Wizard>
+                </React.Fragment>
+            )}
+        </State>
+    ))
+    .add("wizard with disabled previous button", _props => (
+        <State store={store}>
+            {state => (
+                <React.Fragment>
+                    <Button key={0} primary link onClick={() => state.handleToggleWizard(WizardSize.LARGE)}>
+                        OPEN WIZARD
+                    </Button>
+                    <Wizard
+                        currentStepID={state.currentWizardStepID}
+                        key={1}
+                        size={WizardSize.LARGE}
+                        show={state.open}
+                        title="Wizard with dynamic step"
+                        onClose={() => state.handleClose()}
+                        onNext={() => state.addStep(1)}
+                        onPrevious={() => state.handlePrevious()}
+                        onComplete={() => state.handleComplete()}
+                        onNavigateTo={state.handleSelectStep}
+                        disablePreviousButton={true}
+                        showPrevious={true}
                         customFooter={(props: WizardFooterProps) => (
                             <Button primary link onClick={() => state.removeStep(state.currentWizardStepID)}>
                                 Delete Step

--- a/src/newWizard/Wizard.tsx
+++ b/src/newWizard/Wizard.tsx
@@ -42,6 +42,7 @@ import {SpinnerSize} from "../spinner/Spinner";
  * @param {showNext} if true show next button on wizard else hide
  * @param {onPrevious} callback function to call on click of previous button
  * @param {previousClassName} external CSS for previous button
+ * @param {disablePreviousButton} if true then disable previous button
  * @param {nextButtonText} custom text for next button
  * @param {onNext} callback function to call on click of next button
  * @param {nextClassName} external CSS for next button
@@ -102,6 +103,7 @@ export type WizardProps = {
     showPrevious?: boolean;
     previousClassName?: string;
     previousText?: string;
+    disablePreviousButton?: boolean;
     nextText?: string;
     showNext?: boolean;
     nextClassName?: string;
@@ -168,6 +170,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
         showStepTitle: true,
         showTitle: true,
         isLoading: false,
+        disablePreviousButton: false,
         onComplete: () => {
             // by default do nothing in addition the the default handler
         },
@@ -231,6 +234,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
             style,
             isLoading,
             loadingSpinnerSize,
+            disablePreviousButton,
         } = this.props;
 
         // initialize a bunch of class names
@@ -323,6 +327,7 @@ export default class Wizard extends React.PureComponent<WizardProps, WizardState
                                                 currentStepID={currentStepID}
                                                 disableNext={!currentStepIsCompleteAndValid}
                                                 disableComplete={!allStepsCompleteAndValid}
+                                                disablePreviousButton={disablePreviousButton}
                                                 showCancel={showCancel}
                                                 showComplete={!nextStepExists}
                                                 showNext={nextStepExists}

--- a/src/newWizard/WizardFooter.tsx
+++ b/src/newWizard/WizardFooter.tsx
@@ -46,6 +46,7 @@ export interface WizardFooterProps extends InheritedWizardFooterProps {
     showComplete?: boolean;
     showNext?: boolean;
     showPrevious?: boolean;
+    disablePreviousButton?: boolean;
 }
 
 export default class WizardFooter extends React.PureComponent<WizardFooterProps> {
@@ -73,6 +74,7 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
             showNext,
             showPrevious,
             isLoading,
+            disablePreviousButton,
         } = this.props;
 
         return (
@@ -99,7 +101,7 @@ export default class WizardFooter extends React.PureComponent<WizardFooterProps>
                             className={previousClassName}
                             dataqa={dataqa + dataqa_wizard_btn_previous}
                             onClick={onPrevious}
-                            disabled={isLoading}
+                            disabled={isLoading || disablePreviousButton}
                         >
                             {previousText + " "}
                         </Button>


### PR DESCRIPTION
Description:
Added props for disabling previous button as the previous button is being used as Quick-create button in New Object Store.

Screenshots:
![disable-previous](https://user-images.githubusercontent.com/10673883/114863262-23f5b200-9e0d-11eb-92d7-6be2ee1048fc.gif)
