### PR TITLE
[OBSDEF-9382] Hide and show column component should render label as display name when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "0.25.16",
+    "version": "0.25.17",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "0.25.18",
+    "version": "0.25.17",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "0.25.17",
+    "version": "0.25.18",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -32,7 +32,7 @@ export const normalColumns: DataGridColumn[] = [
 // Data for Hide/show columns
 export const hideableColumns: DataGridColumn[] = [
     {columnName: "User ID"},
-    {columnName: "Name"},
+    {columnName: "Name", displayName: "User name"},
     {columnName: "Creation Date", isVisible: false},
     {columnName: "Favorite color", isVisible: false},
 ];

--- a/src/datagrid/HideShowColumns.tsx
+++ b/src/datagrid/HideShowColumns.tsx
@@ -159,7 +159,7 @@ export class HideShowColumns extends React.PureComponent<HideShowColumnsProps, H
                     <CheckBox
                         id={column.columnName}
                         ariaLabel="Select"
-                        label={column.columnName}
+                        label={column.displayName ? column.displayName : column.columnName}
                         onChange={evt => this.handleSingleSelect(column.columnName)}
                         checked={column.isVisible !== undefined ? column.isVisible : undefined}
                     />


### PR DESCRIPTION
This PR includes fix for:
Hide and show column component should render label as display name when available

JIRA-
https://jira.cec.lab.emc.com/browse/OBSDEF-9382

![image](https://user-images.githubusercontent.com/71622688/124457091-11a26900-dda9-11eb-9249-b5baf483f6f7.png)
