### PR TITLE
[OBSDEF - 10007] Changed placeholder text and centered the message to center of datagrid

### DIFF
--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -367,7 +367,7 @@ storiesOf("DataGrid", module)
     ))
     .add("Empty data grid", () => (
         <div style={{width: "80%"}}>
-            <DataGrid columns={normalColumns} footer={defaultFooter} />
+            <DataGrid columns={normalColumns} footer={defaultFooter} style={{height: "70vh"}} />
         </div>
     ))
     .add("Grid with compact row", () => (

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1094,7 +1094,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // Function to create placeholder for empty datagrid
     private buildEmptyPlaceholder(): React.ReactElement {
         const {itemText} = this.state;
-        const placeholderText = "No " + itemText + " found !";
+        const placeholderText = "No " + itemText + " found!";
         return (
             <React.Fragment>
                 <div

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1081,6 +1081,8 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     className={classNames([
                         ClassNames.DATAGRID_PLACEHOLDER,
                         allRows.length === 0 && ClassNames.DATAGRID_EMPTY,
+                        "clr-align-items-center",
+                        "clr-justify-content-center",
                     ])}
                 >
                     {allRows.length === 0 && this.buildEmptyPlaceholder()}
@@ -1092,7 +1094,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     // Function to create placeholder for empty datagrid
     private buildEmptyPlaceholder(): React.ReactElement {
         const {itemText} = this.state;
-        const placeholderText = "We couldn't find any " + itemText + " !";
+        const placeholderText = "No " + itemText + " found !";
         return (
             <React.Fragment>
                 <div


### PR DESCRIPTION
Changes in this PR:

-> Placeholder text is now "No items found!" instead of "We couldn't find any items!"
-> Centered icon in empty container
-> Updated story to reflect the same.

![obsdef-10007-datagrid-related-centering](https://user-images.githubusercontent.com/84840648/126128880-8511b9bd-3cd5-4984-a233-5ee0cb934fa4.gif)
