### PR TITLE
[OBSDEF-11298]: Adding "hideSelectAll" prop in Datagrid to make "Select all" checkbox optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "0.25.27",
+    "version": "0.25.28",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -345,7 +345,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             allRows: [...rows],
             itemText: itemText || DEFAULT_ITEM_TEXT,
             pagination: this.initializePaginationData(),
-            showSelectAll: showSelectAll || false,
+            showSelectAll: showSelectAll || true,
         };
         return dataGridState;
     };

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -36,6 +36,7 @@ import {DataGridColumnResize} from "./DataGridColumnResize";
  * @param {footer} footer component
  * @param {onRowSelect} Function which will gets called on select/deselect of rows
  * @param {onSelectAll} Function which will gets called on select/deselect of all rows
+ * @param {showSelectAll} field if false will not show select all checkbox, by default true
  * @param {keyfield} field to uniquely identify row
  * @param {rowType} Expandable or compact row type
  * @param {itemText} label to display for all items
@@ -54,6 +55,7 @@ type DataGridProps = {
     footer?: DataGridFooter;
     onRowSelect?: (selectedRow: DataGridRow) => void;
     onSelectAll?: (areAllSelected: boolean, selectedRows: DataGridRow[]) => void;
+    showSelectAll?: boolean;
     keyfield?: string;
     rowType?: GridRowType;
     itemText?: string;
@@ -280,6 +282,7 @@ export const DEFAULT_TOTAL_ITEMS: number = 0;
  * @param {itemText} label to display for all items
  * @param {pagination} pagination data
  * @param {isLoading} if true shows loading spinner else shows datagrid
+ * @param {showSelectAll} if false hide select all checkbox, else by default it's true
  */
 type DataGridState = {
     selectAll: boolean;
@@ -288,6 +291,7 @@ type DataGridState = {
     itemText: string;
     pagination?: DataGridPaginationState;
     isLoading: boolean;
+    showSelectAll: boolean;
 };
 
 type DataGridPaginationState = {
@@ -314,6 +318,10 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         this.state = this.initializeDataGridState();
     }
 
+    static defaultProps = {
+        showSelectAll: true,
+    };
+
     componentDidUpdate(prevProps: DataGridProps) {
         const {rows, columns, pagination} = this.props;
         if (rows && rows !== prevProps.rows) {
@@ -327,7 +335,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // Function to initialize datagrid state
     initializeDataGridState = (): DataGridState => {
-        const {isLoading, itemText} = this.props;
+        const {isLoading, itemText, showSelectAll} = this.props;
         const rows = this.initializeRowData();
         const columns = this.initializeColumnData();
         const dataGridState: DataGridState = {
@@ -337,6 +345,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             allRows: [...rows],
             itemText: itemText || DEFAULT_ITEM_TEXT,
             pagination: this.initializePaginationData(),
+            showSelectAll: showSelectAll || false,
         };
         return dataGridState;
     };
@@ -972,7 +981,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // function to render selectAll column
     private buildSelectColumn(): React.ReactElement {
-        const {selectionType, id} = this.props;
+        const {selectionType, id, showSelectAll} = this.props;
         const {selectAll} = this.state;
         return (
             <div
@@ -985,7 +994,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 ])}
             >
                 <span className={ClassNames.DATAGRID_COLUMN_TITLE}>
-                    {selectionType === GridSelectionType.MULTI && (
+                    {selectionType === GridSelectionType.MULTI && showSelectAll && (
                         <div
                             className={classNames([
                                 ClassNames.CLR_CHECKBOX_WRAPPER,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -36,7 +36,7 @@ import {DataGridColumnResize} from "./DataGridColumnResize";
  * @param {footer} footer component
  * @param {onRowSelect} Function which will gets called on select/deselect of rows
  * @param {onSelectAll} Function which will gets called on select/deselect of all rows
- * @param {showSelectAll} when false will not show select all checkbox, by default true
+ * @param {hideSelectAll} when false will not show select all checkbox, by default true
  * @param {keyfield} field to uniquely identify row
  * @param {rowType} Expandable or compact row type
  * @param {itemText} label to display for all items
@@ -55,7 +55,7 @@ type DataGridProps = {
     footer?: DataGridFooter;
     onRowSelect?: (selectedRow: DataGridRow) => void;
     onSelectAll?: (areAllSelected: boolean, selectedRows: DataGridRow[]) => void;
-    showSelectAll?: boolean;
+    hideSelectAll?: boolean;
     keyfield?: string;
     rowType?: GridRowType;
     itemText?: string;
@@ -315,10 +315,6 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         super(props);
         this.state = this.initializeDataGridState();
     }
-
-    static defaultProps = {
-        showSelectAll: true,
-    };
 
     componentDidUpdate(prevProps: DataGridProps) {
         const {rows, columns, pagination} = this.props;
@@ -978,7 +974,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // function to render selectAll column
     private buildSelectColumn(): React.ReactElement {
-        const {selectionType, id, showSelectAll} = this.props;
+        const {selectionType, id, hideSelectAll} = this.props;
         const {selectAll} = this.state;
         return (
             <div
@@ -991,7 +987,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 ])}
             >
                 <span className={ClassNames.DATAGRID_COLUMN_TITLE}>
-                    {selectionType === GridSelectionType.MULTI && showSelectAll && (
+                    {selectionType === GridSelectionType.MULTI && !hideSelectAll && (
                         <div
                             className={classNames([
                                 ClassNames.CLR_CHECKBOX_WRAPPER,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -36,7 +36,7 @@ import {DataGridColumnResize} from "./DataGridColumnResize";
  * @param {footer} footer component
  * @param {onRowSelect} Function which will gets called on select/deselect of rows
  * @param {onSelectAll} Function which will gets called on select/deselect of all rows
- * @param {hideSelectAll} when false will not show select all checkbox, by default true
+ * @param {hideSelectAll} when true will not show select all checkbox, by default false
  * @param {keyfield} field to uniquely identify row
  * @param {rowType} Expandable or compact row type
  * @param {itemText} label to display for all items

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -36,7 +36,7 @@ import {DataGridColumnResize} from "./DataGridColumnResize";
  * @param {footer} footer component
  * @param {onRowSelect} Function which will gets called on select/deselect of rows
  * @param {onSelectAll} Function which will gets called on select/deselect of all rows
- * @param {showSelectAll} field if false will not show select all checkbox, by default true
+ * @param {showSelectAll} when false will not show select all checkbox, by default true
  * @param {keyfield} field to uniquely identify row
  * @param {rowType} Expandable or compact row type
  * @param {itemText} label to display for all items
@@ -282,7 +282,6 @@ export const DEFAULT_TOTAL_ITEMS: number = 0;
  * @param {itemText} label to display for all items
  * @param {pagination} pagination data
  * @param {isLoading} if true shows loading spinner else shows datagrid
- * @param {showSelectAll} if false hide select all checkbox, else by default it's true
  */
 type DataGridState = {
     selectAll: boolean;
@@ -291,7 +290,6 @@ type DataGridState = {
     itemText: string;
     pagination?: DataGridPaginationState;
     isLoading: boolean;
-    showSelectAll: boolean;
 };
 
 type DataGridPaginationState = {
@@ -335,7 +333,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     // Function to initialize datagrid state
     initializeDataGridState = (): DataGridState => {
-        const {isLoading, itemText, showSelectAll} = this.props;
+        const {isLoading, itemText} = this.props;
         const rows = this.initializeRowData();
         const columns = this.initializeColumnData();
         const dataGridState: DataGridState = {
@@ -345,7 +343,6 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             allRows: [...rows],
             itemText: itemText || DEFAULT_ITEM_TEXT,
             pagination: this.initializePaginationData(),
-            showSelectAll: showSelectAll || true,
         };
         return dataGridState;
     };


### PR DESCRIPTION
[OBSDEF-11298]: Adding "hideSelectAll" prop in Datagrid to make "Select all" checkbox optional
Defect: https://jira.cec.lab.emc.com/browse/OBSDEF-11298

Test screenshots -
Default - its False
<img width="656" alt="sel_all_default" src="https://user-images.githubusercontent.com/87687010/132090859-b6de320a-6db6-41aa-b669-757086cf0fbc.PNG">

When "hideSelectAll" set as true - 
<img width="650" alt="sel_all_false_2" src="https://user-images.githubusercontent.com/87687010/132090862-6faeda21-f5cd-4ec5-af29-81344954e29f.PNG">
