### PR TITLE
Stop-Job-to-run-on-master-push

### DIFF
--- a/.github/workflows/github-actions-push-master.yml
+++ b/.github/workflows/github-actions-push-master.yml
@@ -2,10 +2,6 @@ name: clarity-react CI - Push On Master - Pipeline
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/github-actions-push-master.yml
+++ b/.github/workflows/github-actions-push-master.yml
@@ -47,10 +47,4 @@ jobs:
           yarn run publish-public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GIT_TOKEN }}
-          branch: master
-          force: true
+


### PR DESCRIPTION
Remove action to trigger job automatically on master push. this job can be run manually.