### PR TITLE
Feature-obsdef-13999 Added optional parameter for solid icon in tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/forms/tooltip/ToolTip.tsx
+++ b/src/forms/tooltip/ToolTip.tsx
@@ -31,6 +31,7 @@ type ToolTipProps = {
     shape?: string;
     className?: string;
     dataqa?: string;
+    isSolidIcon?: boolean;
 };
 
 export enum ToolTipDirection {
@@ -67,6 +68,7 @@ export const ToolTip: React.FunctionComponent<ToolTipProps> = ({
     className,
     status,
     children,
+    isSolidIcon,
 }) => {
     let setShape: string = shape ? shape : "info-circle";
     return (
@@ -82,7 +84,7 @@ export const ToolTip: React.FunctionComponent<ToolTipProps> = ({
             ])}
             style={style}
         >
-            <Icon shape={setShape} size={iconSize} />
+            <Icon shape={setShape} size={iconSize} className={classNames([isSolidIcon ? "is-solid" : ""])} />
             <span
                 className={classNames([
                     "tooltip-content", //prettier

--- a/src/forms/tooltip/ToolTip.tsx
+++ b/src/forms/tooltip/ToolTip.tsx
@@ -21,6 +21,7 @@ import {Icon} from "../../icon";
  * @param {shape} shape of tooltip
  * @param {className} css div style
  * @param {dataqa} quality engineering field
+ * @param {isSolidIcon} boolean whether tooltip icon should be solid
  */
 type ToolTipProps = {
     direction?: ToolTipDirection;


### PR DESCRIPTION
Added optional parameter for solid icon in tooltip required for DDS Wrapper (isSolidIcon)

type ToolTipProps = {
    direction?: ToolTipDirection;
    size?: ToolTipSize;
    status?: ToolTipStatus;
    style?: any;
    iconSize?: number;
    shape?: string;
    className?: string;
    dataqa?: string;
    isSolidIcon?: boolean;
};