### PR TITLE
[OBSDEF-16020] Correct direction of expand and collapse vertical nav group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/layout/vertical-nav/VerticalNavGroup.tsx
+++ b/src/layout/vertical-nav/VerticalNavGroup.tsx
@@ -70,7 +70,7 @@ export class VerticalNavGroup extends React.PureComponent<VerticalNavGroupProps,
                         <Icon
                             shape="caret"
                             className="nav-group-trigger-icon"
-                            dir={groupIsExpanded ? Direction.RIGHT : Direction.DOWN}
+                            dir={groupIsExpanded ? Direction.DOWN : Direction.RIGHT}
                         />
                     </button>
                 </div>


### PR DESCRIPTION
The `caret ` icon direction should be downward for expansion and right for the collapse. But for the vertical nav group, it was showing it incorrectly. 

![image](https://user-images.githubusercontent.com/51195071/158570661-56f9733e-b505-4383-94cb-169904e3f1bd.png)
