### PR TITLE
[OBSDEF-18239] Fix footer issue on datagrid table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.1.17",
+    "version": "1.1.18",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1071,7 +1071,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
     private buildDataGridBody(): React.ReactElement {
         const {allRows} = this.state;
         return (
-            <div className={ClassNames.DATAGRID} style={{overflow: "initial"}}>
+            <div className={ClassNames.DATAGRID}>
                 <div className={ClassNames.DATAGRID_TABLE_WRAPPER}>
                     <div ref={this.datagridTableRef} className={ClassNames.DATAGRID_TABLE} role="grid">
                         {this.buildDataGridHeader()}

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1131,7 +1131,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         const showEmptyHeader: boolean = rowType && rowType !== GridRowType.COMPACT ? true : false;
 
         return (
-            <div className={ClassNames.DATAGRID_HEADER} style={{position: "relative"}} role="rowgroup">
+            <div className={ClassNames.DATAGRID_HEADER} role="rowgroup">
                 <div className={ClassNames.DATAGRID_ROW} role="row">
                     <div className={ClassNames.DATAGRID_ROW_MASTER}>
                         <div className={ClassNames.DATAGRID_ROW_STICKY}>


### PR DESCRIPTION
## Summary
This PR fixes:
- Footer overflow on data grid table

### Before fix:
![TableOverflow](https://user-images.githubusercontent.com/78294852/173005313-9a50cfdb-7171-4987-98ed-e90f44b293c8.png)

### After fix:
![FixTableOverflow](https://user-images.githubusercontent.com/78294852/173005269-5fb670e6-649f-4931-8dc1-42866d8c5f33.png)
