### PR TITLE
[OBSDEF-OBSDEF-18714] isExpanded prop for already active vertical navigation group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.1.18",
+    "version": "1.1.19",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/layout/vertical-nav/VerticalNav.stories.tsx
+++ b/src/layout/vertical-nav/VerticalNav.stories.tsx
@@ -34,6 +34,18 @@ storiesOf("Vertical Navigation", module)
             </VerticalNavGroup>
         </VerticalNav>
     ))
+    .add("a vertical nav with expanded group", () => (
+        <VerticalNav>
+            <VerticalNavGroup groupName="Group 1">
+                <NavLink>Link 1</NavLink>
+                <NavLink>Link 2</NavLink>
+            </VerticalNavGroup>
+            <VerticalNavGroup groupName="Group 2" isExpanded={true}>
+                <NavLink>Link 3</NavLink>
+                <NavLink>Link 4</NavLink>
+            </VerticalNavGroup>
+        </VerticalNav>
+    ))
     .add("incorporated vertical nav", () => (
         <MainContainer
             title="Project Pokémon"

--- a/src/layout/vertical-nav/VerticalNavGroup.tsx
+++ b/src/layout/vertical-nav/VerticalNavGroup.tsx
@@ -29,6 +29,9 @@ export interface VerticalNavGroupProps {
     // to be opened so that the expanded group can become visible.
     openVerticalNav?: () => void;
 
+    // True if group is already active and expanded
+    isExpanded?: boolean;
+
     className?: string;
 }
 
@@ -39,8 +42,9 @@ interface VerticalNavGroupState {
 export class VerticalNavGroup extends React.PureComponent<VerticalNavGroupProps, VerticalNavGroupState> {
     constructor(props: VerticalNavGroupProps) {
         super(props);
+        const {isExpanded} = this.props;
         this.state = {
-            groupIsExpanded: false,
+            groupIsExpanded: isExpanded || false,
         };
     }
 


### PR DESCRIPTION
**Summary :** 
- Added new prop "isExpanded" in `VerticalNavGroup` component. To check if Nav Group is already active and expanded.
- Added story for same

**Test Link:** 
storybook :   http://10.86.76.248:6006/ 

Storybook:
![OBSDEF-18714-clarity-react](https://user-images.githubusercontent.com/51195071/177557399-54e7a043-20b1-4b5b-9ca4-1ed471556d3b.gif)


vSphere plugin : 
![OBSDEF-18714-after](https://user-images.githubusercontent.com/51195071/177557423-f3d5be4d-5d56-41c8-87c3-e28cf9fd24ff.gif)

