### PR TITLE
[OBSDEF-19538] accordion caret open icon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.1.19",
+    "version": "1.1.20",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/accordian/Accordion.tsx
+++ b/src/accordian/Accordion.tsx
@@ -136,7 +136,11 @@ export class Accordion extends React.Component<AccordionProps, AccordionState> {
                     >
                         <span className={ClassNames.ACCORDION_SR} />
                         <span className={ClassNames.ACCORDION_STATUS}>
-                            <Icon className={ClassNames.ACCORDION_ANGLE} dir={Direction.RIGHT} shape="angle" />
+                            <Icon
+                                className={ClassNames.ACCORDION_ANGLE}
+                                dir={isOpen ? Direction.UP : Direction.RIGHT}
+                                shape="angle"
+                            />
                             <span className={ClassNames.ACCORDION_NUMBER} />
                         </span>
                         <div className={classNames([ClassNames.ACCORDION_TITLE, titleClassName])}>{title}</div>


### PR DESCRIPTION
[OBSDEF-19538](https://jira.cec.lab.emc.com/browse/OBSDEF-19538)

List of changes:
- added condition based caret direction for open and closed.

Note: Given direction up to icon when accordion is open because @clr/ui rotates the icon to 180deg so it will eventually points downwards.

Standalone After change
![AccordionCaretPositionStandalone](https://user-images.githubusercontent.com/95674930/189283256-e2db5d76-d628-4d7a-ab53-c585745f7d9e.gif)

Vsphere After Change:
![AccordionCaretPositionVsphere](https://user-images.githubusercontent.com/95674930/189287077-1ef84f45-f74b-4bad-80be-6acd0452eb96.gif)

Storybook After change:
![AccordionCaretPositionStorybook](https://user-images.githubusercontent.com/95674930/189324686-3466054b-1b45-4365-9560-af3268902a92.gif)



Test Url: http://10.249.253.4:3007
token: eyJhbGciOiJSUzI1NiIsImtpZCI6Im9RNE1BLVlFNU5GYi1qZDdrTld1OG9yVmpmZXhHcW9USkJEWWZNM1MxV1UifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJzdmMtb2JqZWN0c2NhbGUtZG9tYWluLWMyMCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJvYmplY3RzY2FsZS1vcGVyYXRvci10b2tlbi1qYjQycSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJvYmplY3RzY2FsZS1vcGVyYXRvciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImJmYThhN2Q5LTczNWItNGFiOC1hZTNkLTRmMmFkOGM0Y2Y3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpzdmMtb2JqZWN0c2NhbGUtZG9tYWluLWMyMDpvYmplY3RzY2FsZS1vcGVyYXRvciJ9.cljKnTuB-uIXnDfawsy_QqzrBr5bOvZyT2KxqY9h9bPSknpDjFqGKk7cbQnXu20Eei3s22X4330BvKOWr-qdEK3X9xw4BRd_aNClwHpqankj5kz8DxOLcdqQ1doG26EJp8GWhqxQDiJzD4xX8bABv5w_Z-Fg9GyJlY7CHtRit5vCaqPw9zHVNyHkv8YtvimluFvC2ici2nS5zpi04cddOiZTDXU6Q6_fHXIYvanXaaEqsU6BpV21NMJ5iX0_SNbKJcHUwxEtwkXPXho76Sf0ve08KvE0rBQFhBf5tCkZfnrDLTNUuTQ8it3AMVQyCgh_x3O4fxfWfZ4-gJjubcN_GA

Testing:
@tejasjc-ecs 
