### PR TITLE
Fix MainContainer issue

### DIFF
--- a/src/layout/main-container/MainContainer.tsx
+++ b/src/layout/main-container/MainContainer.tsx
@@ -23,11 +23,12 @@ import {ClassNames} from ".";
  */
 export type MainContainerProps = {
     actions?: React.ReactNode;
-    title: string;
+    title?: string;
     headerNav?: any;
     sideNav?: any;
     subNav?: any;
     dataqa?: string;
+    children: JSX.Element | string;
 };
 
 const initialState = {
@@ -70,22 +71,24 @@ export class MainContainer extends React.PureComponent<MainContainerProps> {
         const {primary, secondary} = MainContainer.detectNavs(headerNav, sideNav, subNav);
         return (
             <div className={utils.classNames(this.getClassList())} data-qa={dataqa}>
-                <Header
-                    primaryShown={primary}
-                    secondaryShown={secondary}
-                    onHamburgerToggle={this.handleHamburgerToggle}
-                    onRightSideToggle={this.handleRightSideToggle}
-                    onCloseAll={this.closeAll}
-                >
-                    <div className="branding">
-                        <a href="#" className="nav-link">
-                            <span className="logo dell-emc-logo" />
-                            <span className="title">{title}</span>
-                        </a>
-                    </div>
-                    {headerNav && headerNav}
-                    <div className="header-actions">{actions}</div>
-                </Header>
+                {title && (
+                    <Header
+                        primaryShown={primary}
+                        secondaryShown={secondary}
+                        onHamburgerToggle={this.handleHamburgerToggle}
+                        onRightSideToggle={this.handleRightSideToggle}
+                        onCloseAll={this.closeAll}
+                    >
+                        <div className="branding">
+                            <a href="#" className="nav-link">
+                                <span className="logo dell-emc-logo" />
+                                <span className="title">{title}</span>
+                            </a>
+                        </div>
+                        {headerNav && headerNav}
+                        <div className="header-actions">{actions}</div>
+                    </Header>
+                )}
                 {subNav && subNav}
                 <div className="content-container">
                     <div className="content-area">{children}</div>

--- a/src/layout/main-container/MainContainer.tsx
+++ b/src/layout/main-container/MainContainer.tsx
@@ -20,6 +20,7 @@ import {ClassNames} from ".";
  * @param {sideNav} for side navigation;
  * @param {subNav} for sub navigation;
  * @param {dataqa} for Quality Engineering
+ * @param {children} for content;
  */
 export type MainContainerProps = {
     actions?: React.ReactNode;
@@ -28,7 +29,7 @@ export type MainContainerProps = {
     sideNav?: any;
     subNav?: any;
     dataqa?: string;
-    children: JSX.Element | string;
+    children?: JSX.Element[] | string;
 };
 
 const initialState = {


### PR DESCRIPTION
Make title optional as it's used in documentation
Make Header component render dependent of title being available Add children to props as JSX.Element or string to support content correctly Code passed through prettier

Signed-off-by: Rebecca Frances <rebecca.francescansinos@materialise.com>