### PR TITLE
[OBSDEF-38858] Adding values for datagrid filter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS file
-* @akate1 @maheshkulkarni4 @girishdudhe @spiegela @ben-schumacher
+* @akate1 @maheshkulkarni4 @girishdudhe @spiegela @ben-schumacher @ShitalSD @psivakumaran @m-manaswini @Bhatii

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.2.5",
+    "version": "1.2.7",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGridFilter.tsx
+++ b/src/datagrid/DataGridFilter.tsx
@@ -234,10 +234,13 @@ export class DataGridFilter extends React.PureComponent<DataGridFilterProps, Dat
         this.toggle();
     };
 
-    private closeFilter = () => {
-        this.setState({
-            isOpen: false,
-        });
+    private closeFilter = (evt: any) => {
+        // This should make sure that only scroll events not due to large inputs are handled
+        if (evt.target.nodeName !== "INPUT") {
+            this.setState({
+                isOpen: false,
+            });
+        }
     };
 
     private toggle() {


### PR DESCRIPTION
### Fixes:
- Bumped version of clarity-react
- Added check on scroll event for Datagrid filter. It will now only close if the scroll event is not caused by input

### RCA:

There is a problem currently where adding a long input which does not fit the datagrid filter box makes a scroll event.

Because of this, inputs that are large cannot be added to DatagridFilter.

However, scroll listener was added to close the DatagridFilter on scrolling up or down as without it, the datagrid filter was detaching from the datagrid itself.

Hence modified the code to not close filter if input exceeds datagrid size

### JIRA
https://jira.cec.lab.emc.com/browse/OBSDEF-38858

### Testing:

Jumpbox Link: http://10.227.242.14:3000
Credentials: root/ChangeMe@123 

### Before fix:

![ OBSDEF-38858](https://github.com/EMCECS/clarity-react/assets/84840648/441ec29c-4ad3-4b6f-847a-4bda1c01f63e)

### After fix:

![ OBSDEF-38858-fixed](https://github.com/EMCECS/clarity-react/assets/84840648/e744c61d-bf7e-407b-b939-a511d7713dfb)
