### PR TITLE
Bumping package.json module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,


### PR DESCRIPTION
This is to merely bump the package.json version

Please refer: https://github.com/EMCECS/clarity-react/pull/269#discussion_r1454556314
