### PR TITLE
[OBSDEF-40971] disabled future dates in datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/forms/datepicker/DatePicker.tsx
+++ b/src/forms/datepicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import {classNames} from "../../utils";
  * @param {dataqa} quality engineering testing field
  * @param {onChange} function to call on change of filter value
  * @param {disabled} boolean value to enable or disable filter
- * @param {disableFutureDates} boolean if true, future dates will be disabled. 
+ * @param {disableFutureDates} boolean if true, future dates will be disabled
  */
 export type DatePickerProps = {
     value?: Date;

--- a/src/forms/datepicker/DatePicker.tsx
+++ b/src/forms/datepicker/DatePicker.tsx
@@ -58,7 +58,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
         value: undefined,
         defaultValue: undefined,
         onChange: undefined,
-        disableFutureDates: false
+        disableFutureDates: false,
     };
 
     private calRef = React.createRef<HTMLDivElement>();
@@ -360,7 +360,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
                                                                                     isSelected,
                                                                                     isToday,
                                                                                     isDisabled,
-                                                                                    calendar.isAfter(Moment(), "day")
+                                                                                    calendar.isAfter(Moment(), "day"),
                                                                                 )}
                                                                                 tabIndex={this.calculateTabIndex(
                                                                                     isSelected,

--- a/src/forms/datepicker/DatePicker.tsx
+++ b/src/forms/datepicker/DatePicker.tsx
@@ -360,7 +360,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
                                                                                     isSelected,
                                                                                     isToday,
                                                                                     isDisabled,
-                                                                                    calendar.isAfter(Moment(), "day"),
+                                                                                    calendar.isAfter(Moment(), "day")
                                                                                 )}
                                                                                 tabIndex={this.calculateTabIndex(
                                                                                     isSelected,

--- a/src/forms/datepicker/DatePicker.tsx
+++ b/src/forms/datepicker/DatePicker.tsx
@@ -17,6 +17,7 @@ export type DatePickerProps = {
     dataqa?: string;
     onChange?: (newValue: string | Date) => void;
     disabled?: boolean;
+    disableFutureDates?: boolean;
 };
 
 export type DatePickerState = {
@@ -57,6 +58,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
         value: undefined,
         defaultValue: undefined,
         onChange: undefined,
+        disableFutureDates: false
     };
 
     private calRef = React.createRef<HTMLDivElement>();
@@ -226,12 +228,13 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
         }
     };
 
-    private buildDateClasses(isSelected: boolean, isToday: boolean, isDisabled: boolean) {
+    private buildDateClasses(isSelected: boolean, isToday: boolean, isDisabled: boolean, isFuture: boolean) {
         return classNames([
             "day-btn", // prettier
             isSelected && !isToday && "is-selected",
             isToday && "is-today",
             isDisabled && "is-disabled",
+            isFuture && this.props.disableFutureDates && "is-future",
         ]);
     }
 
@@ -357,6 +360,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
                                                                                     isSelected,
                                                                                     isToday,
                                                                                     isDisabled,
+                                                                                    calendar.isAfter(Moment(), "day"),
                                                                                 )}
                                                                                 tabIndex={this.calculateTabIndex(
                                                                                     isSelected,

--- a/src/forms/datepicker/DatePicker.tsx
+++ b/src/forms/datepicker/DatePicker.tsx
@@ -9,6 +9,9 @@ import {classNames} from "../../utils";
  * @param {locale} regional code
  * @param {defaultValue} default date value
  * @param {dataqa} quality engineering testing field
+ * @param {onChange} function to call on change of filter value
+ * @param {disabled} boolean value to enable or disable filter
+ * @param {disableFutureDates} boolean if true, future dates will be disabled. 
  */
 export type DatePickerProps = {
     value?: Date;


### PR DESCRIPTION
Before
![image](https://github.com/EMCECS/clarity-react/assets/137142337/0cd8cee5-2916-4d76-a013-e910622af162)

After
![image](https://github.com/EMCECS/clarity-react/assets/137142337/d200c0d7-20ee-4f97-91ea-143bd6b4868a)
![image](https://github.com/EMCECS/clarity-react/assets/137142337/5e1cc3c4-22fe-4f37-b23c-830ab2ae6871)
![date](https://github.com/EMCECS/clarity-react/assets/137142337/6790b6c2-813a-436e-accf-756a49d82d43)


Did some changes to disable the future dates in DatePicker for https://jira.cec.lab.emc.com/browse/OBSDEF-40971.
