### PR TITLE
[OBSDEF-46956] DataGrid Pagination Improvments: Revert default prop changes for PageSizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -420,7 +420,7 @@ storiesOf("DataGrid", module)
             />
         </div>
     ))
-    .add("Grid with pagination and pageSizes dropdown", () => (
+    .add("Grid with pagination and custom page size", () => (
         <div style={{width: "80%"}}>
             <DataGrid
                 columns={normalColumns}

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -47,7 +47,7 @@ import {
     paginationDetailsForDetailsPane,
     paginationRowsWithLinks,
     storeForDetailPane,
-    paginationDetailswithDefaultPageSizes,
+    paginationDetailswithPageSizes,
 } from "./DataGridStoriesData";
 import {CustomFilter} from "./CustomFilter";
 import {CustomFilterMulti} from "./CustomFilterMulti";
@@ -420,12 +420,12 @@ storiesOf("DataGrid", module)
             />
         </div>
     ))
-    .add("Grid with pagination and default pageSizes dropdown", () => (
+    .add("Grid with pagination and pageSizes dropdown", () => (
         <div style={{width: "80%"}}>
             <DataGrid
                 columns={normalColumns}
                 rows={paginationRows.slice(0, 10)}
-                pagination={paginationDetailswithDefaultPageSizes}
+                pagination={paginationDetailswithPageSizes}
                 itemText={"Users"}
                 footer={{showFooter: true}}
             />

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -656,11 +656,11 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
         const customPageSize = this.customPageSizeRef.current && this.customPageSizeRef.current.value;
 
         if (pageSize && customPageSize) {
-            if (!isNumber(customPageSize)) {
+            if (!isNumber(customPageSize) || parseInt(customPageSize) === 0) {
                 this.customPageSizeRef.current!.value = pageSize.toString();
             } else {
                 const customPageSizeInt: number = parseInt(customPageSize);
-                if (pageSize !== customPageSizeInt) {
+                if (pageSize !== customPageSizeInt && customPageSizeInt > 0) {
                     if (customPageSizeInt <= maxCustomPageSize) {
                         this.getPage(currentPage, customPageSizeInt);
                     }

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -18,7 +18,6 @@ import {Icon, Direction} from "../icon";
 import {Spinner, SpinnerSize} from "../spinner/Spinner";
 import {HideShowColumns} from "./HideShowColumns";
 import {DataGridColumnResize} from "./DataGridColumnResize";
-import {totalmem} from "os";
 
 /**
  * General component description :

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -664,11 +664,10 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                     if (customPageSizeInt <= maxCustomPageSize) {
                         this.getPage(currentPage, customPageSizeInt);
                     }
-                    //If page size selected by user is greater than maximum limit for custom page size
+                    // If page size selected by user is greater than maximum limit for custom page size
                     else if (customPageSizeInt > maxCustomPageSize && this.customPageSizeRef.current) {
-                        this.customPageSizeRef.current.value =
-                            totalItems < maxCustomPageSize ? totalItems.toString() : maxCustomPageSize.toString();
-                        this.getPage(DEFAULT_CURRENT_PAGE_NUMBER, customPageSizeInt);
+                        const newCustomPageSize = totalItems < maxCustomPageSize ? totalItems : maxCustomPageSize;
+                        this.getPage(DEFAULT_CURRENT_PAGE_NUMBER, newCustomPageSize);
                     }
                 }
             }

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -216,8 +216,9 @@ export type DataGridSort = {
  * @param {pageSizes} Array containing pageSize which user can select from dropdown menu.
  *          Supports custom page sizes. For example["10", "20", "50", "100", CUSTOM_PAGE_SIZE_OPTION]
  * @param {maxCustomPageSize} Maximum limit for custom page size as well as for pageSize dropdown
+ * @param {isCustomPageSizeSelected} set to true if page sizes dropdown is present and custom option is selected
  */
-type DataGridPaginationProps = {
+export type DataGridPaginationProps = {
     className?: string;
     style?: any;
     currentPage?: number;
@@ -227,6 +228,7 @@ type DataGridPaginationProps = {
     compactFooter?: boolean;
     getPageData?: (pageIndex: number, pageSize: number) => Promise<DataGridRow[]>;
     maxCustomPageSize?: number;
+    isCustomPageSizeSelected?: boolean;
 };
 
 /**
@@ -279,7 +281,7 @@ export const DEFAULT_COLUMN_WIDTH: number = 100;
 export const DEFAULT_CURRENT_PAGE_NUMBER: number = 1;
 export const DEFAULT_PAGE_SIZE: number = 10;
 export const DEFAULT_TOTAL_ITEMS: number = 0;
-export const MAX_PAGE_SIZE: number = 1000;
+export const DEFAULT_MAX_PAGE_SIZE: number = 1000;
 export const CUSTOM_PAGE_SIZE_OPTION: string = "Custom";
 
 /**
@@ -401,11 +403,14 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 totalItems,
                 compactFooter,
                 pageSizes,
-                maxCustomPageSize = MAX_PAGE_SIZE,
+                maxCustomPageSize,
+                isCustomPageSizeSelected,
             } = pagination;
             const currentPageNumber: number = currentPage || DEFAULT_CURRENT_PAGE_NUMBER;
             const datagridPageSize: number = pageSize || DEFAULT_PAGE_SIZE;
             const totalItemsInDatagrid: number = totalItems || DEFAULT_TOTAL_ITEMS;
+            const maxCustomPageSizeNumber: number = maxCustomPageSize || DEFAULT_MAX_PAGE_SIZE;
+            const isCustomPageSizeOptionSelected: boolean = isCustomPageSizeSelected || false;
 
             const firstItem: number = this.getFirstItemIndex(currentPageNumber, datagridPageSize);
             const lastItem: number = this.getLastItemIndex(datagridPageSize, totalItemsInDatagrid, firstItem);
@@ -419,7 +424,8 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                 firstItem: firstItem,
                 lastItem: lastItem,
                 totalPages: this.getTotalPages(totalItemsInDatagrid, datagridPageSize),
-                maxCustomPageSize: maxCustomPageSize,
+                maxCustomPageSize: maxCustomPageSizeNumber,
+                isCustomPageSizeSelected: isCustomPageSizeOptionSelected,
             };
 
             return paginationState;
@@ -1513,12 +1519,13 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
 
     //Function to render textbox for custom pageSize
     private buildCustomPageSizeSelect = () => {
+        const {pageSize} = this.state.pagination!;
         return (
             <div className={classNames([ClassNames.PAGINATION_LIST])} style={Styles.PAGINATION_CUSTOM_PAGESIZE}>
                 <input
                     className={ClassNames.PAGINATION_CURRENT}
                     size={4}
-                    defaultValue=""
+                    defaultValue={pageSize}
                     type="text"
                     data-qa="dataqa_datagrid_custom_input"
                     ref={this.customPageSizeRef}
@@ -1542,7 +1549,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
                         <select
                             className={classNames([ClassNames.CLR_PAGE_SIZE_SELECT])}
                             onChange={evt => this.handleSelectPageSize(evt)}
-                            defaultValue={pageSize}
+                            defaultValue={isCustomPageSizeSelected ? CUSTOM_PAGE_SIZE_OPTION : pageSize}
                         >
                             {pageSizes!.map((size: string, index: number) => {
                                 return (

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -15,6 +15,7 @@ import {Button} from "../forms/button";
 import {SortOrder, DataGridRow, DataGridFilterResult, DataGridColumn} from ".";
 import {Password} from "../forms/password/Password";
 import {ToolTip, ToolTipDirection, ToolTipSize} from "../forms/tooltip/ToolTip";
+import {CUSTOM_PAGE_SIZE_OPTION} from "./DataGrid";
 
 /**
  * General file description :
@@ -595,10 +596,11 @@ export const paginationDetails = {
     pageSizes: ["5", "10"],
 };
 
-export const paginationDetailswithDefaultPageSizes = {
+export const paginationDetailswithPageSizes = {
     totalItems: paginationRows.length,
     getPageData: getPageDataForCustomPageSize,
     pageSize: 10,
+    pageSizes: ["10", "20", "50", "100", CUSTOM_PAGE_SIZE_OPTION],
 };
 
 export const paginationDetailsWithCompactFooter = {

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -15,7 +15,7 @@ import {Button} from "../forms/button";
 import {SortOrder, DataGridRow, DataGridFilterResult, DataGridColumn} from ".";
 import {Password} from "../forms/password/Password";
 import {ToolTip, ToolTipDirection, ToolTipSize} from "../forms/tooltip/ToolTip";
-import {CUSTOM_PAGE_SIZE_OPTION} from "./DataGrid";
+import {CUSTOM_PAGE_SIZE_OPTION, DataGridPaginationProps} from "./DataGrid";
 
 /**
  * General file description :
@@ -589,21 +589,22 @@ export const getPageDataForCustomPageSize = (pageIndex: number, pageSize: number
     });
 };
 
-export const paginationDetails = {
+export const paginationDetails: DataGridPaginationProps = {
     totalItems: paginationRows.length,
     getPageData: getPageData,
     pageSize: 5,
     pageSizes: ["5", "10"],
 };
 
-export const paginationDetailswithPageSizes = {
+export const paginationDetailswithPageSizes: DataGridPaginationProps = {
     totalItems: paginationRows.length,
     getPageData: getPageDataForCustomPageSize,
     pageSize: 10,
+    currentPage: 1,
     pageSizes: ["10", "20", "50", "100", CUSTOM_PAGE_SIZE_OPTION],
 };
 
-export const paginationDetailsWithCompactFooter = {
+export const paginationDetailsWithCompactFooter: DataGridPaginationProps = {
     totalItems: paginationRows.length,
     getPageData: getPageData,
     pageSize: 5,
@@ -611,7 +612,7 @@ export const paginationDetailsWithCompactFooter = {
     compactFooter: true,
 };
 
-export const paginationDetailsForAlreadySelectedRows = {
+export const paginationDetailsForAlreadySelectedRows: DataGridPaginationProps = {
     totalItems: alreadySelectedRows.length,
     getPageData: getPageDataForSelectedRows,
     pageSize: 5,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export function allFalseOnKey(obj: any, key: any) {
 
 /**
  * Function to check if input is a number.
- * @param input - The input to be checked.
+ * @param {input} - The input to be checked.
  * @returns True if the input is a number, false otherwise.
  */
 export function isNumber(input: any): boolean {
@@ -63,7 +63,7 @@ export function isNumber(input: any): boolean {
 
 /**
  * Function to check if a key event allows only number inputs.
- * @param evt - The key event to be checked.
+ * @param {evt} - The key event to be checked.
  * @returns True if the event allows only number inputs, false otherwise.
  */
 export function allowOnlyIntegers(evt: any) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,18 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+export const NUMBER_RE = /^[0-9]\d*$/;
 export type ReactChildren = React.ReactNode | (React.ReactNode[] & React.ReactNode);
+
+// Keybord Key Names
+export enum KEYBOARD_KEYS {
+    ESCAPE = "Escape",
+    TAB = "Tab",
+    ENTER = "Enter",
+    SPACE = " ",
+    BACKSPACE = "Backspace",
+    DELETE = "Delete",
+}
 
 export function classNames(classNameList: (false | undefined | null | string)[]) {
     return classNameList.filter(x => typeof x === "string").join(" ");
@@ -37,5 +48,34 @@ export function allFalseOnKey(obj: any, key: any) {
             return false;
         }
     }
+    return true;
+}
+
+/**
+ * Function to check if input is a number.
+ * @param input - The input to be checked.
+ * @returns True if the input is a number, false otherwise.
+ */
+export function isNumber(input: any): boolean {
+    // Test if the input matches the regular expression for a number.
+    return NUMBER_RE.test(input);
+}
+
+/**
+ * Function to check if a key event allows only number inputs.
+ * @param evt - The key event to be checked.
+ * @returns True if the event allows only number inputs, false otherwise.
+ */
+export function allowOnlyIntegers(evt: any) {
+    // Get the ASCII code of the key pressed.
+    var ASCIICode = evt.which ? evt.which : evt.keyCode;
+
+    // Check if the key pressed is not a number (ASCII values between 48 and 57).
+    if (ASCIICode > 31 && (ASCIICode < 48 || ASCIICode > 57)) {
+        // Return false if the key pressed is not a number.
+        evt.preventDefault();
+    }
+
+    // Return true if the key pressed is a number.
     return true;
 }


### PR DESCRIPTION
[OBSDEF-45527](https://jira.cec.lab.emc.com/browse/OBSDEF-45527)

### Summary of the Change
- Made Pagination -> PageSizes prop as optional
- Remove all changes related to default prop for PageSizes
- Added validation for custom page size input for accepting only number values
- Replace deprecated `evt.keycode` with `evt.key`
- Create constant for "Custom" option
- Create enum for common Keyboard keys
- Updated missing documentation

## Screenshot/GIF
#### Before
NA

###
![DatagridCustomPageSizes](https://github.com/EMCECS/clarity-react/assets/51195071/66ed0b82-b618-47c0-82d1-226baff7d004)
# After

## Where to test ?
http://10.227.234.153:6006/?path=/story/datagrid--grid-with-pagination-and-pagesizes-dropdown

## Scenarios verified/Documentation link
_List all the scenarios verified for the changes or link to the manual test documentation for new features_



## Peer Tester Name
_Add team member's name who will test your PR_
@netraja-chavan 
