### PR TITLE
[OBSDEF-44980] Show pagination footer with page sizes dropdown only if number of records are greater than 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dellstorage/clarity-react",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "description": "React components for Clarity UI",
     "license": "Apache-2.0",
     "private": false,

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -48,6 +48,7 @@ import {
     paginationRowsWithLinks,
     storeForDetailPane,
     paginationDetailswithPageSizes,
+    paginationDetailsForLessThan10Records,
 } from "./DataGridStoriesData";
 import {CustomFilter} from "./CustomFilter";
 import {CustomFilterMulti} from "./CustomFilterMulti";
@@ -421,11 +422,22 @@ storiesOf("DataGrid", module)
         </div>
     ))
     .add("Grid with pagination and custom page size", () => (
-        <div style={{width: "80%"}}>
+        <div style={{width: "80%", paddingLeft: "1rem"}}>
+            <br />
+            <span> {"Datagrid with custom page sizes and more than or equal to 10 records."} </span>
             <DataGrid
                 columns={normalColumns}
                 rows={paginationRows.slice(0, 10)}
                 pagination={paginationDetailswithPageSizes}
+                itemText={"Users"}
+                footer={{showFooter: true}}
+            />
+            <br /> <br />
+            <span> {"Datagrid with custom page sizes and less than 10 records."} </span>
+            <DataGrid
+                columns={normalColumns}
+                rows={paginationRows.slice(0, 6)}
+                pagination={paginationDetailsForLessThan10Records}
                 itemText={"Users"}
                 footer={{showFooter: true}}
             />

--- a/src/datagrid/DataGrid.stories.tsx
+++ b/src/datagrid/DataGrid.stories.tsx
@@ -441,6 +441,7 @@ storiesOf("DataGrid", module)
                 itemText={"Users"}
                 footer={{showFooter: true}}
             />
+            <br /> <br />
         </div>
     ))
     .add("Grid with pagination and compact footer", () => (

--- a/src/datagrid/DataGrid.tsx
+++ b/src/datagrid/DataGrid.tsx
@@ -1721,7 +1721,7 @@ export class DataGrid extends React.PureComponent<DataGridProps, DataGridState> 
             const {totalItems, pageSize, pageSizes} = pagination;
             if (totalItems && pageSize) {
                 // Render pagination footer if pageSizes are given or if totalItems are greater than pageSize
-                renderPaginationFooter = pageSizes ? totalItems > 0 : totalItems >= pageSize;
+                renderPaginationFooter = pageSizes ? totalItems >= DEFAULT_PAGE_SIZE : totalItems >= pageSize;
             }
         }
 

--- a/src/datagrid/DataGridStoriesData.tsx
+++ b/src/datagrid/DataGridStoriesData.tsx
@@ -604,6 +604,14 @@ export const paginationDetailswithPageSizes: DataGridPaginationProps = {
     pageSizes: ["10", "20", "50", "100", CUSTOM_PAGE_SIZE_OPTION],
 };
 
+export const paginationDetailsForLessThan10Records: DataGridPaginationProps = {
+    totalItems: 6,
+    getPageData: getPageDataForCustomPageSize,
+    pageSize: 10,
+    currentPage: 1,
+    pageSizes: ["10", "20", "50", "100", CUSTOM_PAGE_SIZE_OPTION],
+};
+
 export const paginationDetailsWithCompactFooter: DataGridPaginationProps = {
     totalItems: paginationRows.length,
     getPageData: getPageData,


### PR DESCRIPTION
[OBSDEF-44980](https://jira.cec.lab.emc.com/browse/OBSDEF-44980)

### Summary of the Change
- Added code to show pagination footer with page sizes dropdown only if the total number of records are greater than 10
- Created story for same

## Screenshot/GIF
#### Before
NA

#### After
Storybook:

![image](https://github.com/EMCECS/clarity-react/assets/51195071/f1dd0798-e57b-4054-aaac-7f61c9416716)

Objectscale Portal UI:
![image](https://github.com/EMCECS/clarity-react/assets/51195071/bf874c16-1906-4fb8-aa95-0510abb88776)


## Where to test ?
Storybook : 
http://10.227.234.153:6006/?path=/story/datagrid--grid-with-pagination-and-pagesizes-dropdown

ObjectScale Portal UI:
http://10.227.234.153:3000/#

## Scenarios verified/Documentation link
_List all the scenarios verified for the changes or link to the manual test documentation for new features_


## Peer Tester Name
_Add team member's name who will test your PR_
@netraja-chavan 
